### PR TITLE
chore: add GitHub repo link to the top right area of each article

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -24,11 +24,17 @@
   },
   "contextual": {
     "options": [
+      {
+        "title": "GitHub",
+        "description": "Open GitHub repository",
+        "href": "https://github.com/ton-org/docs",
+        "icon": "github"
+      },
       "copy",
+      "mcp",
       "chatgpt",
       "claude",
       "perplexity",
-      "mcp",
       "cursor",
       "vscode"
     ]
@@ -541,7 +547,7 @@
   },
   "footer": {
     "socials": {
-      "github": "https://github.com/ton-blockchain",
+      "github": "https://github.com/ton-org/docs",
       "x": "https://twitter.com/ton_blockchain",
       "telegram": "https://t.me/addlist/1r5Vcb8eljk5Yzcy"
     }


### PR DESCRIPTION
That is, except for the `index.mdx`. Also notice that "Edit suggestions" and "Raise issues" buttons would soon be enabled by the end of each page (except `index.mdx`) via the Mintlify's dashboard panel.

Closes #884.

<img width="1898" height="670" alt="image" src="https://github.com/user-attachments/assets/d06ec01b-5c97-4575-af57-53a622f217da" />
