### PR TITLE
fix(whitepapers): redirects for PDFs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3203,6 +3203,11 @@
       "permanent": true
     },
     {
+      "source": "/ton.pdf",
+      "destination": "/resources/pdfs/ton.pdf",
+      "permanent": true
+    },
+    {
       "source": "/tblkch.pdf",
       "destination": "/resources/pdfs/tblkch.pdf",
       "permanent": true

--- a/docs.json
+++ b/docs.json
@@ -3203,11 +3203,6 @@
       "permanent": true
     },
     {
-      "source": "/ton.pdf",
-      "destination": "/resources/pdfs/ton.pdf",
-      "permanent": true
-    },
-    {
       "source": "/tblkch.pdf",
       "destination": "/resources/pdfs/tblkch.pdf",
       "permanent": true

--- a/docs.json
+++ b/docs.json
@@ -3203,27 +3203,27 @@
       "permanent": true
     },
     {
-      "source": "/ton.pdf",
+      "source": "ton.pdf",
       "destination": "/resources/pdfs/ton.pdf",
       "permanent": true
     },
     {
-      "source": "/tblkch.pdf",
+      "source": "tblkch.pdf",
       "destination": "/resources/pdfs/tblkch.pdf",
       "permanent": true
     },
     {
-      "source": "/tvm.pdf",
+      "source": "tvm.pdf",
       "destination": "/resources/pdfs/tvm.pdf",
       "permanent": true
     },
     {
-      "source": "/fiftbase.pdf",
+      "source": "fiftbase.pdf",
       "destination": "/resources/pdfs/fiftbase.pdf",
       "permanent": true
     },
     {
-      "source": "/catchain.pdf",
+      "source": "catchain.pdf",
       "destination": "/resources/pdfs/catchain.pdf",
       "permanent": true
     }

--- a/docs.json
+++ b/docs.json
@@ -3203,27 +3203,27 @@
       "permanent": true
     },
     {
-      "source": "ton.pdf",
+      "source": "/ton.pdf",
       "destination": "/resources/pdfs/ton.pdf",
       "permanent": true
     },
     {
-      "source": "tblkch.pdf",
+      "source": "/tblkch.pdf",
       "destination": "/resources/pdfs/tblkch.pdf",
       "permanent": true
     },
     {
-      "source": "tvm.pdf",
+      "source": "/tvm.pdf",
       "destination": "/resources/pdfs/tvm.pdf",
       "permanent": true
     },
     {
-      "source": "fiftbase.pdf",
+      "source": "/fiftbase.pdf",
       "destination": "/resources/pdfs/fiftbase.pdf",
       "permanent": true
     },
     {
-      "source": "catchain.pdf",
+      "source": "/catchain.pdf",
       "destination": "/resources/pdfs/catchain.pdf",
       "permanent": true
     }

--- a/docs.json
+++ b/docs.json
@@ -3201,6 +3201,31 @@
       "source": "/participate/run-nodes/full-node",
       "destination": "/v3/guidelines/nodes/running-nodes/full-node",
       "permanent": true
+    },
+    {
+      "source": "/ton.pdf",
+      "destination": "/resources/pdfs/ton.pdf",
+      "permanent": true
+    },
+    {
+      "source": "/tblkch.pdf",
+      "destination": "/resources/pdfs/tblkch.pdf",
+      "permanent": true
+    },
+    {
+      "source": "/tvm.pdf",
+      "destination": "/resources/pdfs/tvm.pdf",
+      "permanent": true
+    },
+    {
+      "source": "/fiftbase.pdf",
+      "destination": "/resources/pdfs/fiftbase.pdf",
+      "permanent": true
+    },
+    {
+      "source": "/catchain.pdf",
+      "destination": "/resources/pdfs/catchain.pdf",
+      "permanent": true
     }
   ]
 }

--- a/ton.pdf
+++ b/ton.pdf
@@ -1,0 +1,1 @@
+resources/pdfs/ton.pdf

--- a/ton.pdf
+++ b/ton.pdf
@@ -1,1 +1,0 @@
-resources/pdfs/ton.pdf


### PR DESCRIPTION
Closes #1518. We had similar redirects around 2-3 months ago, before their overhaul, but they didn't work then.

So, PDF redirects work locally, but not in the staging preview. The workaround could (probably) be to make symbolic links from the root. UPD: Nope, symbolic links do not fix this.

In theory, we can do the inverse: place real PDFs in the root and symbolically link to them from `/resources/pdfs/...`. But that might break other places which expect files in the `resources` directory. Let's just report that to Mintlify if we didn't do it yet.

P.S.: As a last resort, we could simply copy-paste those 5 PDFs. Not ideal, but Git should be able to recognize and deduplicate them. Right? UPD: Right, hashes from `git hash-object` are the same, which means that Git stores duplicate PDFs once, and both paths reference the same blob object. Shall we do that @anton-trunov @verytactical?