### PR TITLE
fix: few typos

### DIFF
--- a/contract-dev/first-smart-contract.mdx
+++ b/contract-dev/first-smart-contract.mdx
@@ -126,7 +126,7 @@ The TON ecosystem provides editor plugins with syntax support for IDEs and code 
     - `IncreaseCounter` — contains one field `increaseBy` to increment the counter.
     - `ResetCounter` — resets the counter to 0.
 
-    Each structure has a unique prefix —`0x7e8764ef` and `0x3a752f06`— called opcodes, that  which allows the contract to distinguish between messages.
+    Each structure has a unique prefix —`0x7e8764ef` and `0x3a752f06`— called opcodes, that allows the contract to distinguish between messages.
 
     ```tolk title="./contracts/first_contract.tolk"
     struct(0x7e8764ef) IncreaseCounter {

--- a/foundations/messages/deploy.mdx
+++ b/foundations/messages/deploy.mdx
@@ -32,7 +32,7 @@ _
 
 where the fields are:
 
-- `special`: was mean to register a smart contract for tick-tock events; now is deprecated.
+- `special`: was meant to register a smart contract for tick-tock events; now is deprecated.
 - `code`: the initial code of the contract.
 - `data`: the initial data of the contract.
 - `library`: the initial library of the contract.

--- a/foundations/messages/modes.mdx
+++ b/foundations/messages/modes.mdx
@@ -114,7 +114,7 @@ The following errors can occur during the sending message flow:
 - Malformed message structure, `34` exit code.
 - Invalid destination address in the outbound message, `36` exit code.
 - Not enough value to transfer with the message: all of the inbound message value has been consumed, `37` exit code.
-- No enough funds for processing all message references, `40` exit code.
+- Not enough funds for processing all message references, `40` exit code.
 - The number of bits or references in `StateInit` and message body is too large, `40` exit code.
 - Message has Merkle depth more than two, `40` exit code.
 - If a message has only one `SendRemainingValue` base mode and `final_value` after the step `5` is negative, then an error with `37` exit code is thrown.


### PR DESCRIPTION
Towards #1405 — words themselves are valid, albeit not matching the intent or grammatically invalid.