### PR TITLE
fix(ecosystem): correct manifestUrl examples and add integration troubleshooting

### DIFF
--- a/ecosystem/tma/telegram-ui/getting-started.mdx
+++ b/ecosystem/tma/telegram-ui/getting-started.mdx
@@ -14,10 +14,12 @@ Getting started is a breeze with npm or yarn. Simply run:
 npm install @telegram-apps/telegram-ui
 ```
 
-<Aside type="tip" title="React 19 compatibility">
-  If using `@telegram-apps/telegram-ui` with Next.js 15+ (React 19), create a `.npmrc` file in your project root with `legacy-peer-deps=true` to resolve peer dependency conflicts.
+<Aside
+  type="tip"
+  title="React 19 compatibility"
+>
+  For Next.js 15+ projects that use React 19, create a `.npmrc` file in the project root and set `legacy-peer-deps=true` to resolve peer dependency conflicts.
 </Aside>
-
 
 ## Import styles
 
@@ -75,4 +77,5 @@ export const App = () => (
 With these steps, you're all set to explore the potential of this library.
 
 ### More UI components
+
 Find more demo components [here](https://tgui.xelene.me/?path=/docs/getting-started--documentation).

--- a/ecosystem/tma/telegram-ui/getting-started.mdx
+++ b/ecosystem/tma/telegram-ui/getting-started.mdx
@@ -18,7 +18,7 @@ npm install @telegram-apps/telegram-ui
   type="tip"
   title="React 19 compatibility"
 >
-  For Next.js 15+ projects that use React 19, create a `.npmrc` file in the project root and set `legacy-peer-deps=true` to resolve peer dependency conflicts.
+  If using `@telegram-apps/telegram-ui` with Next.js 15+ (React 19), create a `.npmrc` file in the project root with `legacy-peer-deps=true` to resolve peer dependency conflicts.
 </Aside>
 
 ## Import styles

--- a/ecosystem/tma/telegram-ui/getting-started.mdx
+++ b/ecosystem/tma/telegram-ui/getting-started.mdx
@@ -2,6 +2,8 @@
 title: "Getting started"
 ---
 
+import { Aside } from '/snippets/aside.jsx';
+
 Dive into our sleek design on [Figma](https://figma.com/community/file/1348989725141777736/) to get a glimpse of what awaits you.
 
 ## Easy installation
@@ -11,6 +13,10 @@ Getting started is a breeze with npm or yarn. Simply run:
 ```sh icon="npm"
 npm install @telegram-apps/telegram-ui
 ```
+
+<Aside type="tip" title="React 19 compatibility">
+  If using `@telegram-apps/telegram-ui` with Next.js 15+ (React 19), create a `.npmrc` file in your project root with `legacy-peer-deps=true` to resolve peer dependency conflicts.
+</Aside>
 
 
 ## Import styles

--- a/ecosystem/ton-connect/manifest.mdx
+++ b/ecosystem/ton-connect/manifest.mdx
@@ -41,9 +41,11 @@ For a web dApp, place its manifest at `https://[myapp.com]/tonconnect-manifest.j
   type="caution"
   title="Manifest URL must be an absolute URL"
 >
-  Wallets fetch the manifest independently from outside your app. A relative path like `/tonconnect-manifest.json` will fail silently. Always use the full URL: `https://<YOUR_APP_URL>/tonconnect-manifest.json`.
+  Wallets fetch the manifest independently from outside the app. A relative path like `/tonconnect-manifest.json` will fail silently. Always use the full URL: `https://<APP_URL>/tonconnect-manifest.json`.
 
-  Also make sure `iconUrl` in your manifest points to a valid, accessible image. If the icon returns 404, wallet connection may fail with a generic error.
+  Replace `<APP_URL>` with the public HTTPS origin that serves `tonconnect-manifest.json`.
+
+  Ensure that `iconUrl` in the manifest points to a valid, accessible image. If the icon returns 404, wallet connection may fail with a generic error.
 </Aside>
 
 ## Wallet manifest

--- a/ecosystem/ton-connect/manifest.mdx
+++ b/ecosystem/ton-connect/manifest.mdx
@@ -37,8 +37,11 @@ For a web dApp, place its manifest at `https://[myapp.com]/tonconnect-manifest.j
   Application manifest must be publicly available with CORS disabled, without any authorization required, and without a Cloudflare or similar service proxying them. If hosting that way is troublesome on your own, consider using a trusted CDN.
 </Aside>
 
-<Aside type="caution" title="manifestUrl must be an absolute URL">
-  Wallets fetch the manifest independently from outside your app. A relative path like `/tonconnect-manifest.json` will fail silently. Always use the full URL: `https://your-domain.com/tonconnect-manifest.json`.
+<Aside
+  type="caution"
+  title="Manifest URL must be an absolute URL"
+>
+  Wallets fetch the manifest independently from outside your app. A relative path like `/tonconnect-manifest.json` will fail silently. Always use the full URL: `https://<YOUR_APP_URL>/tonconnect-manifest.json`.
 
   Also make sure `iconUrl` in your manifest points to a valid, accessible image. If the icon returns 404, wallet connection may fail with a generic error.
 </Aside>

--- a/ecosystem/ton-connect/manifest.mdx
+++ b/ecosystem/ton-connect/manifest.mdx
@@ -37,6 +37,12 @@ For a web dApp, place its manifest at `https://[myapp.com]/tonconnect-manifest.j
   Application manifest must be publicly available with CORS disabled, without any authorization required, and without a Cloudflare or similar service proxying them. If hosting that way is troublesome on your own, consider using a trusted CDN.
 </Aside>
 
+<Aside type="caution" title="manifestUrl must be an absolute URL">
+  Wallets fetch the manifest independently from outside your app. A relative path like `/tonconnect-manifest.json` will fail silently. Always use the full URL: `https://your-domain.com/tonconnect-manifest.json`.
+
+  Also make sure `iconUrl` in your manifest points to a valid, accessible image. If the icon returns 404, wallet connection may fail with a generic error.
+</Aside>
+
 ## Wallet manifest
 
 Wallet manifest is a JSON configuration that defines how your wallet interacts with the TON Connect.

--- a/ecosystem/ton-pay/payment-integration/payments-react.mdx
+++ b/ecosystem/ton-pay/payment-integration/payments-react.mdx
@@ -41,14 +41,14 @@ import { TonConnectUIProvider } from "@tonconnect/ui-react";
 
 export function App() {
   return (
-    <TonConnectUIProvider manifestUrl="https://<YOUR_APP_URL>/tonconnect-manifest.json">
+    <TonConnectUIProvider manifestUrl="https://<APP_URL>/tonconnect-manifest.json">
       {/* Application components */}
     </TonConnectUIProvider>
   );
 }
 ```
 
-[The TON Connect manifest](/ecosystem/ton-connect/manifest) file must be publicly accessible and include valid application metadata.
+[The TON Connect manifest](/ecosystem/ton-connect/manifest) file must be publicly accessible and include valid application metadata. Replace `<APP_URL>` with the public HTTPS origin that serves `tonconnect-manifest.json`.
 
 ### Basic implementation
 
@@ -386,7 +386,7 @@ try {
 
   function App() {
     return (
-      <TonConnectUIProvider manifestUrl="https://<YOUR_APP_URL>/tonconnect-manifest.json">
+      <TonConnectUIProvider manifestUrl="https://<APP_URL>/tonconnect-manifest.json">
         <YourComponents />
       </TonConnectUIProvider>
     );

--- a/ecosystem/ton-pay/payment-integration/payments-react.mdx
+++ b/ecosystem/ton-pay/payment-integration/payments-react.mdx
@@ -41,7 +41,7 @@ import { TonConnectUIProvider } from "@tonconnect/ui-react";
 
 export function App() {
   return (
-    <TonConnectUIProvider manifestUrl="/tonconnect-manifest.json">
+    <TonConnectUIProvider manifestUrl="https://your-app.example.com/tonconnect-manifest.json">
       {/* Application components */}
     </TonConnectUIProvider>
   );
@@ -386,7 +386,7 @@ try {
 
   function App() {
     return (
-      <TonConnectUIProvider manifestUrl="/tonconnect-manifest.json">
+      <TonConnectUIProvider manifestUrl="https://your-app.example.com/tonconnect-manifest.json">
         <YourComponents />
       </TonConnectUIProvider>
     );

--- a/ecosystem/ton-pay/payment-integration/payments-react.mdx
+++ b/ecosystem/ton-pay/payment-integration/payments-react.mdx
@@ -41,7 +41,7 @@ import { TonConnectUIProvider } from "@tonconnect/ui-react";
 
 export function App() {
   return (
-    <TonConnectUIProvider manifestUrl="https://your-app.example.com/tonconnect-manifest.json">
+    <TonConnectUIProvider manifestUrl="https://<YOUR_APP_URL>/tonconnect-manifest.json">
       {/* Application components */}
     </TonConnectUIProvider>
   );
@@ -386,7 +386,7 @@ try {
 
   function App() {
     return (
-      <TonConnectUIProvider manifestUrl="https://your-app.example.com/tonconnect-manifest.json">
+      <TonConnectUIProvider manifestUrl="https://<YOUR_APP_URL>/tonconnect-manifest.json">
         <YourComponents />
       </TonConnectUIProvider>
     );

--- a/ecosystem/ton-pay/payment-integration/payments-tonconnect.mdx
+++ b/ecosystem/ton-pay/payment-integration/payments-tonconnect.mdx
@@ -32,7 +32,7 @@ import { TonConnectUIProvider } from "@tonconnect/ui-react";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <TonConnectUIProvider manifestUrl="https://your-app.example.com/tonconnect-manifest.json">
+    <TonConnectUIProvider manifestUrl="https://<YOUR_APP_URL>/tonconnect-manifest.json">
       {children}
     </TonConnectUIProvider>
   );

--- a/ecosystem/ton-pay/payment-integration/payments-tonconnect.mdx
+++ b/ecosystem/ton-pay/payment-integration/payments-tonconnect.mdx
@@ -32,14 +32,14 @@ import { TonConnectUIProvider } from "@tonconnect/ui-react";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <TonConnectUIProvider manifestUrl="https://<YOUR_APP_URL>/tonconnect-manifest.json">
+    <TonConnectUIProvider manifestUrl="https://<APP_URL>/tonconnect-manifest.json">
       {children}
     </TonConnectUIProvider>
   );
 }
 ```
 
-The manifest URL must be publicly accessible and served over HTTPS in production. [The manifest file](/ecosystem/ton-connect/manifest) provides application metadata required for wallet identification.
+The manifest URL must be publicly accessible and served over HTTPS in production. Replace `<APP_URL>` with the public HTTPS origin that serves `tonconnect-manifest.json`. [The manifest file](/ecosystem/ton-connect/manifest) provides application metadata required for wallet identification.
 
 ### Payment component
 

--- a/ecosystem/ton-pay/payment-integration/payments-tonconnect.mdx
+++ b/ecosystem/ton-pay/payment-integration/payments-tonconnect.mdx
@@ -32,7 +32,7 @@ import { TonConnectUIProvider } from "@tonconnect/ui-react";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <TonConnectUIProvider manifestUrl="/tonconnect-manifest.json">
+    <TonConnectUIProvider manifestUrl="https://your-app.example.com/tonconnect-manifest.json">
       {children}
     </TonConnectUIProvider>
   );

--- a/ecosystem/ton-pay/ui-integration/button-js.mdx
+++ b/ecosystem/ton-pay/ui-integration/button-js.mdx
@@ -115,7 +115,7 @@ Placeholders:
 
         // Initialize TonPay client
         const tonPay = createTonPay({
-          manifestUrl: "/tonconnect-manifest.json"
+          manifestUrl: "https://your-app.example.com/tonconnect-manifest.json"
         });
 
         // Define payment handler
@@ -184,7 +184,7 @@ Use `createTonPay` for custom UI and payment flow control.
       import { createTonPay } from "https://unpkg.com/@ton-pay/ui@0.1.1/dist/ton-pay-vanilla.mjs";
 
       const tonPay = createTonPay({
-        manifestUrl: "/tonconnect-manifest.json",
+        manifestUrl: "https://your-app.example.com/tonconnect-manifest.json",
         connectTimeoutMs: 300000 // 5 minutes (optional)
     });
     </script>
@@ -261,7 +261,7 @@ Combine the snippets in this section into one HTML page.
     ```html
     <script type="module">
       const tonPay = createTonPay({
-        manifestUrl: "/tonconnect-manifest.json"
+        manifestUrl: "https://your-app.example.com/tonconnect-manifest.json"
       });
 
       window["<CALLBACK_NAME>"] = async () => {
@@ -416,7 +416,7 @@ TonPayEmbed.click();
   Current wallet address.
 
   ```js
-  const tonPay = createTonPay({ manifestUrl: "/tonconnect-manifest.json" });
+  const tonPay = createTonPay({ manifestUrl: "https://your-app.example.com/tonconnect-manifest.json" });
   console.log(tonPay.address); // null or wallet address
   ```
 
@@ -475,7 +475,7 @@ TonPayEmbed.click();
 </script>
 <script type="module">
   import { createTonPay } from "https://unpkg.com/@ton-pay/ui@0.1.1/dist/ton-pay-vanilla.mjs";
-  const tonPay = createTonPay({ manifestUrl: "/tonconnect-manifest.json" });
+  const tonPay = createTonPay({ manifestUrl: "https://your-app.example.com/tonconnect-manifest.json" });
   window["<CALLBACK_NAME>"] = async () => { /* payment handler */ };
 </script>
 <script src="https://unpkg.com/@ton-pay/ui@0.1.1/dist/ton-pay-embed.js?containerId=<CONTAINER_ID>&callback=<CALLBACK_NAME>"></script>
@@ -491,7 +491,7 @@ Use the complete example of the embed script in a single HTML file.
 import { createTonPay } from "@ton-pay/ui/vanilla";
 
 const tonPay = createTonPay({
-  manifestUrl: "/tonconnect-manifest.json"
+  manifestUrl: "https://your-app.example.com/tonconnect-manifest.json"
 });
 
 // Use tonPay.pay() in event handlers

--- a/ecosystem/ton-pay/ui-integration/button-js.mdx
+++ b/ecosystem/ton-pay/ui-integration/button-js.mdx
@@ -115,7 +115,7 @@ Placeholders:
 
         // Initialize TonPay client
         const tonPay = createTonPay({
-          manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json"
+          manifestUrl: "https://<APP_URL>/tonconnect-manifest.json"
         });
 
         // Define payment handler
@@ -184,7 +184,7 @@ Use `createTonPay` for custom UI and payment flow control.
       import { createTonPay } from "https://unpkg.com/@ton-pay/ui@0.1.1/dist/ton-pay-vanilla.mjs";
 
       const tonPay = createTonPay({
-        manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json",
+        manifestUrl: "https://<APP_URL>/tonconnect-manifest.json",
         connectTimeoutMs: 300000 // 5 minutes (optional)
     });
     </script>
@@ -261,7 +261,7 @@ Combine the snippets in this section into one HTML page.
     ```html
     <script type="module">
       const tonPay = createTonPay({
-        manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json"
+        manifestUrl: "https://<APP_URL>/tonconnect-manifest.json"
       });
 
       window["<CALLBACK_NAME>"] = async () => {
@@ -416,7 +416,7 @@ TonPayEmbed.click();
   Current wallet address.
 
   ```js
-  const tonPay = createTonPay({ manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json" });
+  const tonPay = createTonPay({ manifestUrl: "https://<APP_URL>/tonconnect-manifest.json" });
   console.log(tonPay.address); // null or wallet address
   ```
 
@@ -475,7 +475,7 @@ TonPayEmbed.click();
 </script>
 <script type="module">
   import { createTonPay } from "https://unpkg.com/@ton-pay/ui@0.1.1/dist/ton-pay-vanilla.mjs";
-  const tonPay = createTonPay({ manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json" });
+  const tonPay = createTonPay({ manifestUrl: "https://<APP_URL>/tonconnect-manifest.json" });
   window["<CALLBACK_NAME>"] = async () => { /* payment handler */ };
 </script>
 <script src="https://unpkg.com/@ton-pay/ui@0.1.1/dist/ton-pay-embed.js?containerId=<CONTAINER_ID>&callback=<CALLBACK_NAME>"></script>
@@ -491,7 +491,7 @@ Use the complete example of the embed script in a single HTML file.
 import { createTonPay } from "@ton-pay/ui/vanilla";
 
 const tonPay = createTonPay({
-  manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json"
+  manifestUrl: "https://<APP_URL>/tonconnect-manifest.json"
 });
 
 // Use tonPay.pay() in event handlers

--- a/ecosystem/ton-pay/ui-integration/button-js.mdx
+++ b/ecosystem/ton-pay/ui-integration/button-js.mdx
@@ -115,7 +115,7 @@ Placeholders:
 
         // Initialize TonPay client
         const tonPay = createTonPay({
-          manifestUrl: "https://your-app.example.com/tonconnect-manifest.json"
+          manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json"
         });
 
         // Define payment handler
@@ -184,7 +184,7 @@ Use `createTonPay` for custom UI and payment flow control.
       import { createTonPay } from "https://unpkg.com/@ton-pay/ui@0.1.1/dist/ton-pay-vanilla.mjs";
 
       const tonPay = createTonPay({
-        manifestUrl: "https://your-app.example.com/tonconnect-manifest.json",
+        manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json",
         connectTimeoutMs: 300000 // 5 minutes (optional)
     });
     </script>
@@ -261,7 +261,7 @@ Combine the snippets in this section into one HTML page.
     ```html
     <script type="module">
       const tonPay = createTonPay({
-        manifestUrl: "https://your-app.example.com/tonconnect-manifest.json"
+        manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json"
       });
 
       window["<CALLBACK_NAME>"] = async () => {
@@ -416,7 +416,7 @@ TonPayEmbed.click();
   Current wallet address.
 
   ```js
-  const tonPay = createTonPay({ manifestUrl: "https://your-app.example.com/tonconnect-manifest.json" });
+  const tonPay = createTonPay({ manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json" });
   console.log(tonPay.address); // null or wallet address
   ```
 
@@ -475,7 +475,7 @@ TonPayEmbed.click();
 </script>
 <script type="module">
   import { createTonPay } from "https://unpkg.com/@ton-pay/ui@0.1.1/dist/ton-pay-vanilla.mjs";
-  const tonPay = createTonPay({ manifestUrl: "https://your-app.example.com/tonconnect-manifest.json" });
+  const tonPay = createTonPay({ manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json" });
   window["<CALLBACK_NAME>"] = async () => { /* payment handler */ };
 </script>
 <script src="https://unpkg.com/@ton-pay/ui@0.1.1/dist/ton-pay-embed.js?containerId=<CONTAINER_ID>&callback=<CALLBACK_NAME>"></script>
@@ -491,7 +491,7 @@ Use the complete example of the embed script in a single HTML file.
 import { createTonPay } from "@ton-pay/ui/vanilla";
 
 const tonPay = createTonPay({
-  manifestUrl: "https://your-app.example.com/tonconnect-manifest.json"
+  manifestUrl: "https://<YOUR_APP_URL>/tonconnect-manifest.json"
 });
 
 // Use tonPay.pay() in event handlers

--- a/ecosystem/ton-pay/ui-integration/button-react.mdx
+++ b/ecosystem/ton-pay/ui-integration/button-react.mdx
@@ -54,7 +54,7 @@ import { Image } from "/snippets/image.jsx";
 
     function App() {
       return (
-        <TonConnectUIProvider manifestUrl="https://your-app.example.com/tonconnect-manifest.json">
+        <TonConnectUIProvider manifestUrl="https://<YOUR_APP_URL>/tonconnect-manifest.json">
           <AppRoutes />
         </TonConnectUIProvider>
       );

--- a/ecosystem/ton-pay/ui-integration/button-react.mdx
+++ b/ecosystem/ton-pay/ui-integration/button-react.mdx
@@ -54,7 +54,7 @@ import { Image } from "/snippets/image.jsx";
 
     function App() {
       return (
-        <TonConnectUIProvider manifestUrl="https://<YOUR_APP_URL>/tonconnect-manifest.json">
+        <TonConnectUIProvider manifestUrl="https://<APP_URL>/tonconnect-manifest.json">
           <AppRoutes />
         </TonConnectUIProvider>
       );

--- a/ecosystem/ton-pay/ui-integration/button-react.mdx
+++ b/ecosystem/ton-pay/ui-integration/button-react.mdx
@@ -54,7 +54,7 @@ import { Image } from "/snippets/image.jsx";
 
     function App() {
       return (
-        <TonConnectUIProvider manifestUrl="/tonconnect-manifest.json">
+        <TonConnectUIProvider manifestUrl="https://your-app.example.com/tonconnect-manifest.json">
           <AppRoutes />
         </TonConnectUIProvider>
       );


### PR DESCRIPTION
## What

Several TON Pay documentation pages use relative `manifestUrl` in code examples (e.g., `manifestUrl="/tonconnect-manifest.json"`). This doesn't work — wallets fetch the manifest externally and can't resolve relative paths. Developers get a generic "manifest load failed" error with no hint about the actual problem.

Also added troubleshooting notes for common integration gotchas.

## Changes

- Fixed `manifestUrl` examples from relative to absolute URLs across TON Pay pages (`button-react.mdx`, `button-js.mdx`, `payments-react.mdx`, `payments-tonconnect.mdx`)
- Added caution note to manifest docs: URL must be absolute, `iconUrl` must be accessible
- Added React 19 compatibility note for `@telegram-apps/telegram-ui` with Next.js 15+

## Context

Ran into all of these while building a Telegram Mini App with TON payments. Each one cost 15-30 min to debug. These fixes would save that time for every new TMA developer.

Related: #1836, #2004
Closes #2031.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a tip for React 19 / Next.js 15+ users about setting legacy peer-deps to resolve dependency issues.
  * Clarified TON Connect manifest must use an absolute HTTPS URL (relative paths may fail).
  * Warned that manifest icon URL must be publicly accessible to avoid connection failures.
  * Updated examples to use absolute HTTPS manifest URLs for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->