### PR TITLE
feat(ton-pay): remove production recommendation note

### DIFF
--- a/ecosystem/ton-pay/quick-start.mdx
+++ b/ecosystem/ton-pay/quick-start.mdx
@@ -214,13 +214,6 @@ Before installing and setting up the TON Pay SDK, the application must provide a
 
     In a client-only flow, persist the `reference` after `pay(createMessage)` resolves and returns it. This is enough to resume status checks after a reload during polling, but it does not cover the period while the wallet approval screen is open. To avoid that gap, create the transfer on the server and persist the `reference` before opening the wallet.
 
-    <Aside
-      type="note"
-      title="Production recommendation"
-    >
-      SDK polling is suitable for quick starts and simple client flows. For reliable order fulfillment, persist the `reference` on the server and combine client polling with [webhooks](/ecosystem/ton-pay/webhooks).
-    </Aside>
-
     ```tsx title="Result handling example" expandable
     import { useState } from "react";
     import { TonPayButton, useTonPay } from "@ton-pay/ui-react";


### PR DESCRIPTION
Closes #2030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the quick-start guide by removing a production recommendation section that addressed SDK polling limitations, server-side transaction reference persistence patterns, and webhook integration strategies for reliable order fulfillment in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->