### PR TITLE
chore(internal-infra): bump action, node.js, and npm versions

### DIFF
--- a/.github/workflows/bouncer.yml
+++ b/.github/workflows/bouncer.yml
@@ -29,8 +29,9 @@ jobs:
     steps:
       - name: Check if a number of additions modulo filtered files is within the threshold
         id: stats
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          # language=JavaScript
           script: |
             const maxAdditions = Number(process.env.MAX_ADDITIONS ?? '600');
             await exec.exec('sleep 0.5s');
@@ -54,8 +55,9 @@ jobs:
 
       - name: ${{ steps.stats.outputs.trigger == 'true' && 'An opened PR is too big to be reviewed at once!' || '...' }}
         if: github.event.action == 'opened' && steps.stats.outputs.trigger == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          # language=JavaScript
           script: |
             await exec.exec('sleep 0.5s');
             await github.rest.issues.createComment({
@@ -84,8 +86,9 @@ jobs:
 
       - name: ${{ steps.stats.outputs.trigger == 'true' && 'Some change in the PR made it too big!' || '...' }}
         if: github.event.action != 'opened' && steps.stats.outputs.trigger == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          # language=JavaScript
           script: |
             core.setFailed([
               [
@@ -107,8 +110,9 @@ jobs:
       # pr title check
       - name: "Check that the title conforms to the simplified version of Conventional Commits"
         if: ${{ !cancelled() }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          # language=JavaScript
           script: |
             const title = context.payload.pull_request.title;
             const types = 'feat|fix|chore|refactor|test';
@@ -126,8 +130,9 @@ jobs:
       # pr close issue limits
       - name: "Check that there is no more than ${{ env.MAX_ISSUES_PER_PR }} linked issues"
         if: ${{ !cancelled() && github.event.pull_request.user.login != 'dependabot[bot]' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          # language=JavaScript
           script: |
             const maxIssuesAllowed = Number(process.env.MAX_ISSUES_PER_PR ?? '3');
             const body = context.payload.pull_request.body || '';

--- a/.github/workflows/commander.yml
+++ b/.github/workflows/commander.yml
@@ -3,7 +3,7 @@ name: 📡 Commander
 
 env:
   HUSKY: 0
-  NODE_VERSION: 20
+  NODE_VERSION: 22
 
 on:
   issue_comment:

--- a/.github/workflows/commander.yml
+++ b/.github/workflows/commander.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           ref: ${{ env.HEAD_REF }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         if: env.IS_FORK != 'true'

--- a/.github/workflows/commander.yml
+++ b/.github/workflows/commander.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           FROM_PR: ${{ github.event.pull_request.number }}
           FROM_ISSUE: ${{ github.event.issue.number }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const fs = require('node:fs');
@@ -69,14 +69,14 @@ jobs:
 
       - name: Checkout the PR branch
         if: env.IS_FORK != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.HEAD_REF }}
           fetch-depth: 0
 
       - name: Setup Node.js
         if: env.IS_FORK != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -90,7 +90,7 @@ jobs:
       - name: Get changed MDX and Markdown files
         if: env.IS_FORK != 'true'
         id: changed-files
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
         with:
           files: |
             **.md
@@ -103,8 +103,9 @@ jobs:
         id: fix-fmt
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          # language=JavaScript
           script: |
             const files = (process.env.ALL_CHANGED_FILES ?? '')
               .trim().split(' ').filter(Boolean).filter((it) => it.match(/\.mdx?$/) !== null);
@@ -128,7 +129,7 @@ jobs:
 
       - name: Commit changes, if any
         if: env.IS_FORK != 'true' && steps.fix-fmt.outputs.changes == 'true'
-        uses: stefanzweifel/git-auto-commit-action@28e16e81777b558cc906c8750092100bbb34c5e3 # v7.0.0
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: "fix: formatting"
           branch: ${{ env.HEAD_REF }}

--- a/.github/workflows/commander.yml
+++ b/.github/workflows/commander.yml
@@ -69,14 +69,14 @@ jobs:
 
       - name: Checkout the PR branch
         if: env.IS_FORK != 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.HEAD_REF }}
           fetch-depth: 0
 
       - name: Setup Node.js
         if: env.IS_FORK != 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/generate-api-tables.yml
+++ b/.github/workflows/generate-api-tables.yml
@@ -19,13 +19,13 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/generate-api-tables.yml
+++ b/.github/workflows/generate-api-tables.yml
@@ -2,7 +2,7 @@ name: Generate API Tables
 
 env:
   PYTHON_VERSION: "3.11"
-  NODE_VERSION: "20"
+  NODE_VERSION: "22"
 
 on:
   push:

--- a/.github/workflows/generate-api-tables.yml
+++ b/.github/workflows/generate-api-tables.yml
@@ -19,13 +19,13 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/generate-api-tables.yml
+++ b/.github/workflows/generate-api-tables.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/instructions.yml
+++ b/.github/workflows/instructions.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # needed for pushing later
+          persist-credentials: false
 
       - name: Set up Git
         run: |

--- a/.github/workflows/instructions.yml
+++ b/.github/workflows/instructions.yml
@@ -23,7 +23,7 @@ jobs:
       SOURCE_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.source_branch || 'master' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # needed for pushing later
 
@@ -33,7 +33,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -57,7 +57,7 @@ jobs:
       - name: Create Pull Request if needed
         if: ${{ steps.git-diff.outputs.changed != '' }}
         id: cpr
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           commit-message: "feat: update TVM instructions list"
           title: "feat: update TVM instructions list"

--- a/.github/workflows/instructions.yml
+++ b/.github/workflows/instructions.yml
@@ -23,7 +23,7 @@ jobs:
       SOURCE_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.source_branch || 'master' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # needed for pushing later
 
@@ -33,7 +33,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get changed MDX and Markdown files
         id: changed-files
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
         with:
           files: |
             **.md
@@ -51,8 +51,9 @@ jobs:
         id: check-fmt
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          # language=JavaScript
           script: |
             const files = (process.env.ALL_CHANGED_FILES ?? '')
               .trim().split(' ').filter(Boolean).filter((it) => it.match(/\.mdx?$/) !== null);
@@ -93,8 +94,9 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
           SUCCESS: ${{ steps.check-fmt.conclusion == 'failure' && 'false' || 'true' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          # language=JavaScript
           script: |
             const { hidePriorCommentsWithPrefix, createComment } = await import('${{ github.workspace }}/.github/scripts/common.mjs');
             const success = JSON.parse(process.env.SUCCESS ?? 'false');
@@ -121,12 +123,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         # The fetch-depth is not set to 0 to prevent the cspell-action
         # from misfiring on files that are in main but not on this PR branch
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -138,7 +140,7 @@ jobs:
 
       - name: Run CSpell on changed files
         # This action also annotates the PR
-        uses: streetsidesoftware/cspell-action@v7
+        uses: streetsidesoftware/cspell-action@9cd41bb518a24fefdafd9880cbab8f0ceba04d28 # 8.3.0
         with:
           check_dot_files: explicit
           suggestions: true
@@ -149,12 +151,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -157,6 +157,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,7 +2,7 @@ name: 💅 Linting suite
 
 env:
   HUSKY: 0
-  NODE_VERSION: 20
+  NODE_VERSION: 22
 
 on:
   pull_request:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -123,12 +123,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         # The fetch-depth is not set to 0 to prevent the cspell-action
         # from misfiring on files that are in main but not on this PR branch
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -151,12 +151,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -124,8 +125,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        # The fetch-depth is not set to 0 to prevent the cspell-action
-        # from misfiring on files that are in main but not on this PR branch
+        with:
+          persist-credentials: false
+          # The fetch-depth is not set to 0 to prevent the cspell-action
+          # from misfiring on files that are in main but not on this PR branch
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/pitaya.yml
+++ b/.github/workflows/pitaya.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -241,7 +241,7 @@ jobs:
 
       - name: Setup Python
         if: env.DOCS_CHANGED == 'true' && (env.IS_FORK != 'true' || github.event_name != 'pull_request')
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -251,7 +251,7 @@ jobs:
 
       - name: Checkout Pitaya
         if: env.DOCS_CHANGED == 'true' && (env.IS_FORK != 'true' || github.event_name != 'pull_request')
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: tact-lang/pitaya
           path: pitaya-src
@@ -473,7 +473,7 @@ jobs:
 
       - name: Upload artifacts
         if: env.DOCS_CHANGED == 'true' && (env.IS_FORK != 'true' || github.event_name != 'pull_request') && steps.pitaya_artifacts.outputs.has_artifacts == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pitaya-logs-${{ github.run_id }}
           path: pitaya-src/pitaya-artifacts.tar.gz

--- a/.github/workflows/pitaya.yml
+++ b/.github/workflows/pitaya.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -241,17 +241,17 @@ jobs:
 
       - name: Setup Python
         if: env.DOCS_CHANGED == 'true' && (env.IS_FORK != 'true' || github.event_name != 'pull_request')
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Setup uv
         if: env.DOCS_CHANGED == 'true' && (env.IS_FORK != 'true' || github.event_name != 'pull_request')
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Checkout Pitaya
         if: env.DOCS_CHANGED == 'true' && (env.IS_FORK != 'true' || github.event_name != 'pull_request')
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tact-lang/pitaya
           path: pitaya-src
@@ -473,7 +473,7 @@ jobs:
 
       - name: Upload artifacts
         if: env.DOCS_CHANGED == 'true' && (env.IS_FORK != 'true' || github.event_name != 'pull_request') && steps.pitaya_artifacts.outputs.has_artifacts == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pitaya-logs-${{ github.run_id }}
           path: pitaya-src/pitaya-artifacts.tar.gz

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 # do not run postinstall or other lifecycle scripts
 ignore-scripts=true
-# each package version should be at least 3 days old
-min-release-age=3
+# each package version should be at least 7 days old
+min-release-age=7

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# do not run postinstall or other lifecycle scripts
+ignore-scripts=true
+# each package version should be at least 3 days old
+min-release-age=3

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "unist-util-visit-parents": "^6.0.2"
   },
   "engines": {
-    "node": ">=20.17",
-    "npm": ">=9"
+    "node": ">=22.22",
+    "npm": ">=10"
   },
-  "packageManager": "npm@9.9.4"
+  "packageManager": "npm@10.9.7"
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "engines": {
     "node": ">=22.22",
-    "npm": ">=10"
+    "npm": ">=11"
   },
-  "packageManager": "npm@10.9.7"
+  "packageManager": "npm@11.11.1"
 }


### PR DESCRIPTION
Closes #2045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped required runtimes: Node >=22.22 and npm >=11.
  * Updated declared package manager to npm@11.11.1.
  * Added npm config to disable lifecycle scripts and enforce a 7‑day minimum release age.
  * Upgraded and pinned CI/CD workflow tooling to newer stable releases and tightened checkout/security settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->