### PR TITLE
fix(sub-second): set correct speed and interval numbers

### DIFF
--- a/ecosystem/subsecond.mdx
+++ b/ecosystem/subsecond.mdx
@@ -20,7 +20,7 @@ The upgrade targets a block interval of 400ms (down from \~2.5s on current mainn
 | -------------- | -------------- | ----------------- | ---------------- |
 | Mainnet today  | \~2.5s         | \~0.4             | \~10s            |
 | Testnet today  | \~450ms        | \~2.2             | \~1–2s           |
-| Mainnet target | 400ms      | \~2.5–5           | \~1s             |
+| Mainnet target | 400ms          | \~2.5–5           | \~1s             |
 
 Together with consensus update, there is a Streaming API v2 from TON Center to receive transaction status updates with 30–100ms latency.
 

--- a/ecosystem/subsecond.mdx
+++ b/ecosystem/subsecond.mdx
@@ -12,7 +12,7 @@ However, a faster blockchain does not automatically improve user experience. Thi
 
 ## Current status
 
-The upgrade targets a block interval of 200–400ms (down from \~2.5s on current mainnet), roughly 2.5–5x throughput in blocks per second, and a finalization lag of \~1s versus the current \~10s.
+The upgrade targets a block interval of 400ms (down from \~2.5s on current mainnet), roughly 2.5–5x throughput in blocks per second, and a finalization lag of \~1s versus the current \~10s.
 
 <Aside type="note">Mainnet activation is targeting early April 2026.</Aside>
 
@@ -20,7 +20,7 @@ The upgrade targets a block interval of 200–400ms (down from \~2.5s on current
 | -------------- | -------------- | ----------------- | ---------------- |
 | Mainnet today  | \~2.5s         | \~0.4             | \~10s            |
 | Testnet today  | \~450ms        | \~2.2             | \~1–2s           |
-| Mainnet target | 200–400ms      | \~2.5–5           | \~1s             |
+| Mainnet target | 400ms      | \~2.5–5           | \~1s             |
 
 Together with consensus update, there is a Streaming API v2 from TON Center to receive transaction status updates with 30–100ms latency.
 
@@ -67,8 +67,8 @@ A faster chain alone does not reduce end-to-end latency if the application conti
 
 ### Indexers
 
-Indexers must process up to 10x more blocks per second without accumulating lag.
-If it was tuned for 2.5s block intervals, it will fall behind under 200-400ms intervals.
+Indexers must process up to 6x more blocks per second without accumulating lag.
+If it was tuned for 2.5s block intervals, it will fall behind under 400ms intervals.
 
 #### Actions
 
@@ -87,7 +87,7 @@ If it was tuned for 2.5s block intervals, it will fall behind under 200-400ms in
 
 ### Behavior without Streaming APIs
 
-Even if the blockchain produces blocks up to 10x faster, apps that do not use Streaming APIs still:
+Even if the blockchain produces blocks up to 6x faster, apps that do not use Streaming APIs still:
 
 - Poll HTTP endpoints at fixed intervals.
 - Wait for full block finalization before updating the UI.
@@ -251,7 +251,7 @@ Example subscription (send flow):
 
 ## Test on testnet
 
-Testnet runs at sub-second speed (200–400ms block finality). Run tests here before enabling sub-second changes on mainnet.
+Testnet runs at sub-second speed (400ms block finality). Run tests here before enabling sub-second changes on mainnet.
 
 ### Testnet endpoints
 


### PR DESCRIPTION
Closes https://github.com/ton-org/docs/issues/2065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Catchain 2.0 specifications with a fixed 400ms block interval target
  * Refined ecosystem guidance and performance scaling metrics for the new specifications
  * Updated testnet documentation with revised finality parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->