### PR TITLE
fix(sub-second): set correct blocks per second

### DIFF
--- a/ecosystem/subsecond.mdx
+++ b/ecosystem/subsecond.mdx
@@ -12,7 +12,7 @@ However, a faster blockchain does not automatically improve user experience. Thi
 
 ## Current status
 
-The upgrade targets a block interval of 400ms (down from \~2.5s on current mainnet), roughly 2.5–5x throughput in blocks per second, and a finalization lag of \~1s versus the current \~10s.
+The upgrade targets a block interval of 400ms (down from \~2.5s on current mainnet), roughly 2.5x throughput in blocks per second, and a finalization lag of \~1s versus the current \~10s.
 
 <Aside type="note">Mainnet activation is targeting early April 2026.</Aside>
 
@@ -20,7 +20,7 @@ The upgrade targets a block interval of 400ms (down from \~2.5s on current mainn
 | -------------- | -------------- | ----------------- | ---------------- |
 | Mainnet today  | \~2.5s         | \~0.4             | \~10s            |
 | Testnet today  | \~450ms        | \~2.2             | \~1–2s           |
-| Mainnet target | 400ms          | \~2.5–5           | \~1s             |
+| Mainnet target | 400ms          | \~2.5             | \~1s             |
 
 Together with consensus update, there is a Streaming API v2 from TON Center to receive transaction status updates with 30–100ms latency.
 

--- a/ecosystem/subsecond.mdx
+++ b/ecosystem/subsecond.mdx
@@ -12,7 +12,7 @@ However, a faster blockchain does not automatically improve user experience. Thi
 
 ## Current status
 
-The upgrade targets a block interval of 400ms (down from \~2.5s on current mainnet), roughly 2.5x throughput in blocks per second, and a finalization lag of \~1s versus the current \~10s.
+The upgrade targets a block interval of 400ms (down from \~2.5s on current mainnet), roughly 6.25x throughput in blocks per second, and a finalization lag of \~1s versus the current \~10s.
 
 <Aside type="note">Mainnet activation is targeting early April 2026.</Aside>
 


### PR DESCRIPTION
Closes https://github.com/ton-org/docs/issues/2067
2.5-5 -> 2.5 blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined mainnet throughput guidance: the reported blocks-per-second estimate was narrowed from a previous range to a single clarified value (~2.5), improving clarity in the "Current status" performance section without changing surrounding content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->