### PR TITLE
chore(sub-second): mark upgrade as live on mainnet, document TonAPI streaming

### DIFF
--- a/.cspell.jsonc
+++ b/.cspell.jsonc
@@ -57,6 +57,7 @@
         "ShardChain->shardchain",
         "StateInit->`StateInit`",
         "TLB->TL-B",
+        "TONAPI->TonAPI",
         "Toncenter->TON Center",
         "toncoins->Toncoin",
         "Toncoins->Toncoin",

--- a/ecosystem/api/overview.mdx
+++ b/ecosystem/api/overview.mdx
@@ -7,19 +7,31 @@ Access TON data via public liteservers, hosted APIs (TON Center v2/v3, TonAPI, d
 
 ## Comparison table
 
-| Feature                   | Public liteservers                                                                  | TON Center v2                                       | TON Center v3                                      | TonAPI                                                                                   | dTON                                       |
-| ------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------ |
-| **Can be self-hosted?**   | ✅                                                                                  | ✅                                                  | ✅                                                 | ❌                                                                                       | ❌                                         |
-| **Open-source**           | ✅                                                                                  | ✅                                                  | ✅                                                 | 🟡 Limited<sup>1</sup>                                                                   | ❌                                         |
-| **Indexer**<sup>2</sup>   | ❌                                                                                  | ❌                                                  | ✅                                                 | ✅                                                                                       | ✅                                         |
-| **Archival**<sup>3</sup>  | 🟡 Varies                                                                           | 🟡 Depends on liteserver                            | ✅                                                 | ✅                                                                                       | ✅                                         |
-| **Proofs**<sup>4</sup>    | ✅                                                                                  | ❌                                                  | ❌                                                 | ❌                                                                                       | ❌                                         |
-| **Mainnet endpoint**      | [Config](https://ton-blockchain.github.io/global.config.json)                       | [Endpoint](https://toncenter.com/api/v2)            | [Endpoint](https://toncenter.com/api/v3)           | [Endpoint](https://tonapi.io/v2)                                                         | [GraphQL](https://dton.io/graphql)         |
-| **Testnet endpoint**      | [Config](https://ton-blockchain.github.io/testnet-global.config.json)               | [Endpoint](https://testnet.toncenter.com/api/v2)    | [Endpoint](https://testnet.toncenter.com/api/v3)   | [Endpoint](https://testnet.tonapi.io/v2)                                                 | [GraphQL](https://testnet.dton.io/graphql) |
-| **Source / Deploy guide** | [Run node / liteserver](/ecosystem/nodes/cpp/setup-mytonctrl#liteserver-quickstart) | [Deploy](https://github.com/toncenter/ton-http-api) | [Source](https://github.com/toncenter/ton-indexer) | [OpenTonAPI](https://github.com/tonkeeper/opentonapi)<sup>1</sup>                        | —                                          |
-| **Documentation**         | [Guide](/ecosystem/nodes/overview#interacting-with-ton-nodes)                       | [Docs](/ecosystem/api/toncenter/v2/overview)        | [Docs](/ecosystem/api/toncenter/v3/overview)       | [REST](https://docs.tonconsole.com/tonapi/rest-api), [Swagger](https://tonapi.io/api-v2) | [Site](https://docs.dton.io/)              |
+### Polling
 
-<sup>1</sup> TonAPI's full indexer is not open-source; [OpenTonAPI](https://github.com/tonkeeper/opentonapi) is a limited open-source version.
+| Feature                   | Public liteservers                | TON Center v2            | TON Center v3         | TonAPI                                  | dTON              |
+| ------------------------- | --------------------------------- | ------------------------ | --------------------- | --------------------------------------- | ----------------- |
+| **Can be self-hosted?**   | ✅                                | ✅                       | ✅                    | ❌                                      | ❌                |
+| **Open-source**           | ✅                                | ✅                       | ✅                    | 🟡 Limited<sup>1</sup>                  | ❌                |
+| **Indexer**<sup>2</sup>   | ❌                                | ❌                       | ✅                    | ✅                                      | ✅                |
+| **Archival**<sup>3</sup>  | 🟡 Varies                         | 🟡 Depends on liteserver | ✅                    | ✅                                      | ✅                |
+| **Proofs**<sup>4</sup>    | ✅                                | ❌                       | ❌                    | ❌                                      | ❌                |
+| **Mainnet endpoint**      | [Config][c]                       | [Endpoint][etc-v2]       | [Endpoint][etc-v3]    | [Endpoint][eta-v2]                      | [GraphQL][edt]    |
+| **Testnet endpoint**      | [Config][c-tn]                    | [Endpoint][etc-v2-tn]    | [Endpoint][etc-v3-tn] | [Endpoint][eta-v2-tn]                   | [GraphQL][edt-tn] |
+| **Source / Deploy guide** | [Run node / liteserver][ls-setup] | [Deploy][etc-v2-src]     | [Source][etc-v3-src]  | [OpenTonAPI][eta-oss-src]<sup>1</sup>   | —                 |
+| **Documentation**         | [Guide][ls-doc]                   | [Docs][etc-v2-doc]       | [Docs][etc-v3-doc]    | [REST][eta-doc], [Swagger][eta-swagger] | [Site][edt-doc]   |
+
+### Streaming
+
+| Feature                    | TON Center Streaming API v2                | TonAPI Streaming API                       |
+| -------------------------- | ------------------------------------------ | ------------------------------------------ |
+| **Protocol compatibility** | Native reference implementation            | Compatible with TON Center                 |
+| **Mainnet endpoints**      | [SSE][etc-sse], [WebSocket][etc-wss]       | [SSE][eta-sse], [WebSocket][eta-wss]       |
+| **Testnet endpoints**      | [SSE][etc-sse-tn], [WebSocket][etc-wss-tn] | [SSE][eta-sse-tn], [WebSocket][eta-wss-tn] |
+| **Authentication**         | [TON Center][etc-key]                      | [Ton Console][eta-key]                     |
+| **Documentation**          | [Docs][etc-stream-doc]                     | [Same as TON Center][etc-stream-doc]       |
+
+<sup>1</sup> TonAPI's full indexer is not open-source; [OpenTonAPI][eta-oss-src] is a limited open-source version.
 
 <sup>2</sup> **Indexer** means the service maintains its own database derived from blockchain data for richer queries (traces, jettons, NFTs, etc.), beyond raw liteserver RPC.
 
@@ -30,11 +42,57 @@ Access TON data via public liteservers, hosted APIs (TON Center v2/v3, TonAPI, d
 ## References
 
 - [TON node and liteserver source](https://github.com/ton-blockchain/ton)
-- [Mainnet liteserver config](https://ton-blockchain.github.io/global.config.json), [testnet config](https://ton-blockchain.github.io/testnet-global.config.json)
+- [Mainnet liteserver config][c], [testnet config][c-tn]
 - [TON Center landing page](https://toncenter.com)
-- [TON Center v2 (Python, older) source and deploy instructions](https://github.com/toncenter/ton-http-api)
+- [TON Center v2 (Python, older) source and deploy instructions][etc-v2-src]
 - [TON Center v2 (C++, newer) source and deploy instructions](https://github.com/toncenter/ton-http-api-cpp)
-- [TON Center v3 source and deploy instructions](https://github.com/toncenter/ton-indexer)
-- [TonAPI site](https://tonapi.io), [REST docs](https://docs.tonconsole.com/tonapi/rest-api), [Swagger](https://tonapi.io/api-v2)
-- [OpenTonAPI (limited open-source)](https://github.com/tonkeeper/opentonapi)
-- [dTON GraphQL](https://dton.io/graphql)
+- [TON Center v3 source and deploy instructions][etc-v3-src]
+- [TonAPI site](https://tonapi.io), [REST docs][eta-doc], [Swagger][eta-swagger]
+- [OpenTonAPI (limited open-source)][eta-oss-src]
+- [dTON GraphQL][edt]
+
+{/* Config */}
+
+[c]: https://ton-blockchain.github.io/global.config.json
+[c-tn]: https://ton-blockchain.github.io/testnet-global.config.json
+
+{/* TON Center */}
+
+[etc-v2]: https://toncenter.com/api/v2
+[etc-v2-tn]: https://testnet.toncenter.com/api/v2
+[etc-v2-src]: https://github.com/toncenter/ton-http-api
+[etc-v2-doc]: /ecosystem/api/toncenter/v2/overview
+[etc-v3]: https://toncenter.com/api/v3
+[etc-v3-tn]: https://testnet.toncenter.com/api/v3
+[etc-v3-src]: https://github.com/toncenter/ton-indexer
+[etc-v3-doc]: /ecosystem/api/toncenter/v3/overview
+[etc-sse]: https://toncenter.com/api/streaming/v2/sse
+[etc-sse-tn]: https://testnet.toncenter.com/api/streaming/v2/sse
+[etc-wss]: wss://toncenter.com/api/streaming/v2/ws
+[etc-wss-tn]: wss://testnet.toncenter.com/api/streaming/v2/ws
+[etc-key]: /ecosystem/api/toncenter/get-api-key
+[etc-stream-doc]: /ecosystem/api/toncenter/streaming/overview
+
+{/* TON API */}
+
+[eta-v2]: https://tonapi.io/v2
+[eta-v2-tn]: https://testnet.tonapi.io/v2
+[eta-oss-src]: https://github.com/tonkeeper/opentonapi
+[eta-doc]: https://docs.tonconsole.com/tonapi/rest-api
+[eta-swagger]: https://tonapi.io/api-v2
+[eta-sse]: https://tonapi.io/streaming/v2/sse
+[eta-sse-tn]: https://testnet.tonapi.io/streaming/v2/sse
+[eta-wss]: wss://tonapi.io/streaming/v2/ws
+[eta-wss-tn]: wss://testnet.tonapi.io/streaming/v2/ws
+[eta-key]: https://tonconsole.com/tonapi/api-keys
+
+{/* dTON */}
+
+[edt]: https://dton.io/graphql
+[edt-tn]: https://testnet.dton.io/graphql
+[edt-doc]: https://docs.dton.io/
+
+{/* Liteservers */}
+
+[ls-setup]: /ecosystem/nodes/cpp/setup-mytonctrl#liteserver-quickstart
+[ls-doc]: /ecosystem/nodes/overview#interacting-with-ton-nodes

--- a/ecosystem/api/overview.mdx
+++ b/ecosystem/api/overview.mdx
@@ -7,7 +7,7 @@ Access TON data via public liteservers, hosted APIs (TON Center v2/v3, TonAPI, d
 
 ## Comparison table
 
-### Polling
+### Requests
 
 | Feature                   | Public liteservers                | TON Center v2            | TON Center v3         | TonAPI                                  | dTON              |
 | ------------------------- | --------------------------------- | ------------------------ | --------------------- | --------------------------------------- | ----------------- |
@@ -21,6 +21,14 @@ Access TON data via public liteservers, hosted APIs (TON Center v2/v3, TonAPI, d
 | **Source / Deploy guide** | [Run node / liteserver][ls-setup] | [Deploy][etc-v2-src]     | [Source][etc-v3-src]  | [OpenTonAPI][eta-oss-src]<sup>1</sup>   | —                 |
 | **Documentation**         | [Guide][ls-doc]                   | [Docs][etc-v2-doc]       | [Docs][etc-v3-doc]    | [REST][eta-doc], [Swagger][eta-swagger] | [Site][edt-doc]   |
 
+<sup>1</sup> TonAPI's full indexer is not open-source; [OpenTonAPI][eta-oss-src] is a limited open-source version.
+
+<sup>2</sup> **Indexer** means the service maintains its own database derived from blockchain data for richer queries (traces, jettons, NFTs, etc.), beyond raw liteserver RPC.
+
+<sup>3</sup> **Archival** indicates historical data retention. For liteservers, this depends on the node's archival configuration; hosted indexers typically keep full history, but exact retention policies are service-specific.
+
+<sup>4</sup> **Proofs** denote responses that can be verified without trust using cryptographic proofs from the network (liteserver/tonlib-based). HTTP indexers typically do not return proof bundles in their REST/GraphQL responses.
+
 ### Streaming
 
 | Feature                    | TON Center Streaming API v2                | TonAPI Streaming API                       |
@@ -30,14 +38,6 @@ Access TON data via public liteservers, hosted APIs (TON Center v2/v3, TonAPI, d
 | **Testnet endpoints**      | [SSE][etc-sse-tn], [WebSocket][etc-wss-tn] | [SSE][eta-sse-tn], [WebSocket][eta-wss-tn] |
 | **Authentication**         | [TON Center][etc-key]                      | [Ton Console][eta-key]                     |
 | **Documentation**          | [Docs][etc-stream-doc]                     | [Same as TON Center][etc-stream-doc]       |
-
-<sup>1</sup> TonAPI's full indexer is not open-source; [OpenTonAPI][eta-oss-src] is a limited open-source version.
-
-<sup>2</sup> **Indexer** means the service maintains its own database derived from blockchain data for richer queries (traces, jettons, NFTs, etc.), beyond raw liteserver RPC.
-
-<sup>3</sup> **Archival** indicates historical data retention. For liteservers, this depends on the node's archival configuration; hosted indexers typically keep full history, but exact retention policies are service-specific.
-
-<sup>4</sup> **Proofs** denote responses that can be verified without trust using cryptographic proofs from the network (liteserver/tonlib-based). HTTP indexers typically do not return proof bundles in their REST/GraphQL responses.
 
 ## References
 

--- a/ecosystem/api/toncenter/streaming/overview.mdx
+++ b/ecosystem/api/toncenter/streaming/overview.mdx
@@ -25,6 +25,15 @@ Streaming API serves as a real-time, streaming version of the [indexed access la
   The [API v2](/ecosystem/api/toncenter/v2/overview) and [API v3](/ecosystem/api/toncenter/v3/overview) include their major version numbers in their product names. For the Streaming API, `v2` means the current protocol version and doesn't refer to different APIs.
 </Aside>
 
+<Aside
+  type="note"
+  title="Compatibility with TonAPI"
+>
+  TonAPI exposes compatible Streaming API endpoints for the same SSE and WebSocket protocol. The request fields, event types, and finality model documented on this page also apply there.
+
+  Authentication uses a [Ton Console API key](https://tonconsole.com/tonapi/api-keys).
+</Aside>
+
 ## Event groups
 
 The Streaming API emits the following event groups:

--- a/ecosystem/api/toncenter/streaming/sse.mdx
+++ b/ecosystem/api/toncenter/streaming/sse.mdx
@@ -16,6 +16,18 @@ Send one `POST` request to the SSE endpoint with a JSON body that defines the su
 - Mainnet: `https://toncenter.com/api/streaming/v2/sse`
 - Testnet: `https://testnet.toncenter.com/api/streaming/v2/sse`
 
+<Aside
+  type="note"
+  title="TonAPI endpoint compatibility"
+>
+  TonAPI supports the same SSE subscription format on different endpoints:
+
+  - Mainnet: `https://tonapi.io/streaming/v2/sse`
+  - Testnet: `https://testnet.tonapi.io/streaming/v2/sse`
+
+  Authentication uses a [Ton Console API key](https://tonconsole.com/tonapi/api-keys).
+</Aside>
+
 ### Request fields
 
 <ParamField

--- a/ecosystem/api/toncenter/streaming/wss.mdx
+++ b/ecosystem/api/toncenter/streaming/wss.mdx
@@ -18,6 +18,18 @@ Each request may include an optional `id` field for request and response correla
 - Mainnet: `wss://toncenter.com/api/streaming/v2/ws`
 - Testnet: `wss://testnet.toncenter.com/api/streaming/v2/ws`
 
+<Aside
+  type="note"
+  title="TonAPI endpoint compatibility"
+>
+  TonAPI supports the same WebSocket subscription format on different endpoints:
+
+  - Mainnet: `wss://tonapi.io/streaming/v2/ws`
+  - Testnet: `wss://testnet.tonapi.io/streaming/v2/ws`
+
+  Authentication uses a [Ton Console API key](https://tonconsole.com/tonapi/api-keys).
+</Aside>
+
 ### Operations
 
 #### `subscribe`

--- a/ecosystem/subsecond.mdx
+++ b/ecosystem/subsecond.mdx
@@ -6,21 +6,21 @@ tag: "take action"
 
 import { Aside } from '/snippets/aside.jsx';
 
-The TON Core team has [released Catchain 2.0](https://t.me/toncore/104) on mainnet. This consensus upgrade enables sub-second block finality and brings the on-chain experience closer to Web2 responsiveness.
+The TON Core team has [released Catchain 2.0](https://t.me/toncore/104) on mainnet. This consensus upgrade enables sub-second block finality, reducing the block interval from about 2.5s to about 400ms.
 
-However, faster block production does not automatically improve user experience or application latency. Projects must adapt their apps to expose the improvement to users.
+However, faster block production does not automatically reduce end-to-end latency for users. Projects must adapt their applications so transaction status updates and UI changes use the new timing guarantees.
 
 ## Current status
 
 <Aside type="note">Sub-second finality is live on TON mainnet.</Aside>
 
-Mainnet runs with a block interval of about 400ms instead of \~2.5s before the upgrade, producing roughly 6.25x more blocks per second. Target finalization lag is reduced from \~10s to about 1s.
+As of April 9th 2026, mainnet runs with a block interval of about 400 ms instead of \~2.5 s before the upgrade, producing roughly 6.25x more blocks per second. Target finalization lag is reduced from \~10 s to about 1 s.
 
-| Network        | Block interval | Blocks per second | Finalization lag |
-| -------------- | -------------- | ----------------- | ---------------- |
-| Mainnet before | \~2.5s         | \~0.4             | \~10s            |
-| Mainnet today  | \~400ms        | \~2.5             | \~1s             |
-| Testnet today  | \~450ms        | \~2.2             | \~1–2s           |
+| Network                      | Block interval | Blocks per second | Finalization lag |
+| ---------------------------- | -------------- | ----------------- | ---------------- |
+| Mainnet                      | \~400ms        | \~2.5             | \~1s             |
+| Testnet                      | \~450ms        | \~2.2             | \~1–2s           |
+| Mainnet before Apr 9th, 2026 | \~2.5s         | \~0.4             | \~10s            |
 
 - Together with the consensus update, the [Streaming API v2](#ton-center-streaming-api-v2) delivers status updates with 30 to 100ms latency.
 - Testnet remains the primary environment for project testing.
@@ -113,7 +113,7 @@ User perception: "You said the blockchain is fast. Why does my transfer still ta
 
 ### Why this matters
 
-The sub-second finality upgrade is live, but coordinated ecosystem changes are still required:
+The sub-second finality upgrade is enabled on mainnet, but coordinated ecosystem changes are still required:
 
 - TON Core delivers faster block production and low-latency APIs.
 - Ecosystem projects must adapt indexers and UI layers to surface this speed.

--- a/ecosystem/subsecond.mdx
+++ b/ecosystem/subsecond.mdx
@@ -6,25 +6,24 @@ tag: "take action"
 
 import { Aside } from '/snippets/aside.jsx';
 
-The TON Core team is [releasing Catchain 2.0](https://t.me/toncore/99), a consensus upgrade targeting sub-second finality to bring the on-chain experience closer to Web2 responsiveness.
+The TON Core team has [released Catchain 2.0](https://t.me/toncore/104) on mainnet. This consensus upgrade enables sub-second block finality and brings the on-chain experience closer to Web2 responsiveness.
 
-However, a faster blockchain does not automatically improve user experience. This upgrade delivers the speed — projects must adapt their apps to surface it to users.
+However, faster block production does not automatically improve user experience or application latency. Projects must adapt their apps to expose the improvement to users.
 
 ## Current status
 
-The upgrade targets a block interval of 400ms (down from \~2.5s on current mainnet), roughly 6.25x throughput in blocks per second, and a finalization lag of \~1s versus the current \~10s.
+<Aside type="note">Sub-second finality is live on TON mainnet.</Aside>
 
-<Aside type="note">Mainnet activation is targeting early April 2026.</Aside>
+Mainnet runs with a block interval of about 400ms instead of \~2.5s before the upgrade, producing roughly 6.25x more blocks per second. Target finalization lag is reduced from \~10s to about 1s.
 
 | Network        | Block interval | Blocks per second | Finalization lag |
 | -------------- | -------------- | ----------------- | ---------------- |
-| Mainnet today  | \~2.5s         | \~0.4             | \~10s            |
+| Mainnet before | \~2.5s         | \~0.4             | \~10s            |
+| Mainnet today  | \~400ms        | \~2.5             | \~1s             |
 | Testnet today  | \~450ms        | \~2.2             | \~1–2s           |
-| Mainnet target | 400ms          | \~2.5             | \~1s             |
 
-Together with consensus update, there is a Streaming API v2 from TON Center to receive transaction status updates with 30–100ms latency.
-
-Testnet operates close to the target speed and is the primary environment for testing projects.
+- Together with the consensus update, the [Streaming API v2](#ton-center-streaming-api-v2) delivers status updates with 30 to 100ms latency.
+- Testnet remains the primary environment for project testing.
 
 ## Example of sub-second user experience in action
 
@@ -36,8 +35,7 @@ Testnet operates close to the target speed and is the primary environment for te
   alt="Example of sub-second user experience"
 />
 
-[MyTonWallet](https://mytonwallet.io/) and [tonscan.org](https://tonscan.org) already use Streaming API v2 on both mainnet and testnet to deliver transaction status updates with low latency.
-This has already nearly halved the reaction time in these products, even though sub-second finality is not yet enabled on mainnet.
+[MyTonWallet](https://mytonwallet.io/) and [tonscan.org](https://tonscan.org) already use Streaming API v2 on both mainnet and testnet to deliver transaction status updates with low latency. These projects have nearly halved interface delays, and the mainnet upgrade will further reduce them.
 
 ## What projects need to do
 
@@ -47,8 +45,8 @@ A faster chain alone does not reduce end-to-end latency if the application conti
 
 #### Actions
 
-- Switch to [TON Center Streaming API v2](#ton-center-streaming-api-v2).
-  Handle all four transaction statuses: `"pending"`, `"confirmed"`, `"finalized"`, `"trace_invalidated"`.
+- Switch to a streaming API such as [TON Center Streaming API v2](#ton-center-streaming-api-v2) or [TonAPI Streaming API](#tonapi-streaming-api).
+  Handle all four transaction statuses: `"pending"`, `"confirmed"`, `"finalized"`, and `"trace_invalidated"`.
 
 - If Streaming API cannot be used, reduce polling intervals and adjust assumptions about transaction timing.
   Interfaces should be designed to expect results in under 1 second.
@@ -59,26 +57,24 @@ A faster chain alone does not reduce end-to-end latency if the application conti
 
 1. Update all self-hosted components to the versions that include Catchain 2.0 support:
 
-   - TON node and liteserver – update to the latest release before mainnet activation.
-   - Self-hosted TON Center – update to the version with Streaming API v2 support.
+   - TON node and liteserver – update to a release that supports the live mainnet consensus.
+   - Self-hosted TON Center – update to a version with Streaming API v2 support.
 
-1. After updating, connect each component to testnet and verify that it operates correctly under the higher block rate.
-   Do not wait for mainnet activation; issues identified late are harder to resolve.
+1. After updating, verify each component on testnet and confirm that it operates correctly under the higher block rate. If any component still runs a pre-upgrade version, update it before relying on it in production.
 
 ### Indexers
 
-Indexers must process up to 6x more blocks per second without accumulating lag.
-If it was tuned for 2.5s block intervals, it will fall behind under 400ms intervals.
+Indexers must process about 6.25x more blocks per second without accumulating lag. If an indexer was tuned for 2.5s block intervals, it can fall behind under 400ms intervals.
 
 #### Actions
 
 1. Connect the indexer to testnet.
 
-1. Run for 30+ minutes.
+1. Run for 30 or more minutes.
 
 1. Measure lag continuously.
 
-1. If lag increases, identify and resolve bottlenecks (e.g., database writes, network, parsing) before mainnet activation.
+1. If lag increases, identify and resolve bottlenecks such as database writes, network latency, and parsing throughput.
 
 1. Generate the typical mainnet load profile on testnet and verify that the indexer keeps up.
    See [Expected user experience](#expected-user-experience) and [Test on testnet](#test-on-testnet) for guidance.
@@ -87,7 +83,7 @@ If it was tuned for 2.5s block intervals, it will fall behind under 400ms interv
 
 ### Behavior without Streaming APIs
 
-Even if the blockchain produces blocks up to 6x faster, apps that do not use Streaming APIs still:
+Even with blocks produced about 6.25x faster, applications that do not use the Streaming API would still:
 
 - Poll HTTP endpoints at fixed intervals.
 - Wait for full block finalization before updating the UI.
@@ -100,7 +96,7 @@ A typical sequence for polling-based integrations:
 1. \~0.8s – shard block committed to masterchain;
 1. \~10s – UI updates on the next HTTP polling request.
 
-User perception: "You said the blockchain is fast. Why does my transfer still take 10 seconds?"
+User perception: "You said the blockchain is fast. Why does my transfer still take 10 seconds?". In this model, the blockchain is fast, but the user interface still appears slow.
 
 ### Behavior with Streaming APIs
 
@@ -112,18 +108,17 @@ User perception: "You said the blockchain is fast. Why does my transfer still ta
 <Aside
   type="caution"
 >
-  If your UI does not update fast enough, users will not notice any improvement despite the blockchain upgrade.
+  If the interface does not update quickly, users will not notice any improvement despite the blockchain upgrade.
 </Aside>
 
 ### Why this matters
 
-The sub-second finality update rollout requires coordinated changes across the ecosystem:
+The sub-second finality upgrade is live, but coordinated ecosystem changes are still required:
 
 - TON Core delivers faster block production and low-latency APIs.
 - Ecosystem projects must adapt indexers and UI layers to surface this speed.
 
-If apps do not adapt, the upgrade appears ineffective, even when the underlying system operates correctly.
-Projects that are ready before the mainnet rollout will demonstrate the intended behavior and user experience.
+If applications do not adapt, the upgrade will not become apparent. Projects that have adapted will showcase the intended behavior and user experience.
 
 ## How to integrate
 
@@ -131,10 +126,10 @@ Projects that are ready before the mainnet rollout will demonstrate the intended
 
 For projects building on TON:
 
-- Streaming API: [TON Center Streaming API v2](#ton-center-streaming-api-v2).
-- Data layer: [TON Center v3][toncenter].
+- Streaming API: [TON Center](#ton-center-streaming-api-v2) or [TonAPI](#tonapi-streaming-api).
+- Data layer: [TON Center API v3](/ecosystem/api/toncenter/v3/overview) or TonAPI v2.
 - SDK: [AppKit][appkit] for balances, tokens, NFTs, and contract interactions.
-- Finality: wait `"finalized"` status for critical flows.
+- Finality: wait for `"finalized"` in critical flows.
 
 ### Public liteserver
 
@@ -181,6 +176,17 @@ SSE and WebSocket are available. Choose based on the stack:
 | --------- | ---------------------------------------------------- | -------------------------------------------- |
 | SSE       | `https://testnet.toncenter.com/api/streaming/v2/sse` | `https://toncenter.com/api/streaming/v2/sse` |
 | WebSocket | `wss://testnet.toncenter.com/api/streaming/v2/ws`    | `wss://toncenter.com/api/streaming/v2/ws`    |
+
+<Aside type="note">
+  TonAPI also exposes Streaming API endpoints with the same SSE and WebSocket interface. Use the TON Center's [Streaming API v2 documentation][streaming] as the protocol reference.
+
+  | Protocol  | Testnet URL                                  | Mainnet URL                          |
+  | --------- | -------------------------------------------- | ------------------------------------ |
+  | SSE       | `https://testnet.tonapi.io/streaming/v2/sse` | `https://tonapi.io/streaming/v2/sse` |
+  | WebSocket | `wss://testnet.tonapi.io/streaming/v2/ws`    | `wss://tonapi.io/streaming/v2/ws`    |
+
+  Authentication uses a [Ton Console API key](https://tonconsole.com/tonapi/api-keys).
+</Aside>
 
 <Aside
   type="caution"
@@ -234,6 +240,10 @@ Example subscription (send flow):
 - Send a `ping` every 15 seconds to keep the connection alive.
 - SSE connections receive automatic server-side keepalive (`: keepalive`) every 15 seconds; no client action required.
 
+### TonAPI Streaming API
+
+TonAPI Streaming API's interface is fully compatible and can be used interchangeably with TON Center's [Streaming API v2][streaming].
+
 ### AppKit for app developers
 
 [AppKit][appkit] provides ready-to-use components for frontend applications. It handles out of the box:
@@ -244,18 +254,13 @@ Example subscription (send flow):
 - Contract state reads;
 - Transaction sending, including jetton transfers.
 
-<Aside type="note">
-  AppKit and [WalletKit](/ecosystem/walletkit/overview) support for Streaming API v2 is in development and will be available soon.
-  Projects using these SDKs should follow this guide for Streaming API integration until native support is available.
-</Aside>
-
 ## Test on testnet
 
-Testnet runs at sub-second speed (400ms block finality). Run tests here before enabling sub-second changes on mainnet.
+Testnet runs at sub-second block generation speed. Use it for testing projects before shipping production changes on mainnet.
 
 ### Testnet endpoints
 
-Use the [public API endpoints overview](/ecosystem/api/overview) for testnet endpoints, including TON Center v2 and v2.
+Use the [public API endpoints overview](/ecosystem/api/overview) for testnet endpoints, including TON Center and TonAPI streaming endpoints.
 
 ### How to get test tokens
 
@@ -293,7 +298,7 @@ Perform the following tests to validate UX and wallet behavior.
 - [TON Core R\&D technical overview, Telegram channel](https://t.me/toncore/98)
 - [UX approaches for sub-second finality, Telegraph](https://telegra.ph/New-Approaches-to-Blockchain-User-Experience-08-02)
 - [TON Center Streaming API v2][streaming]
-- [TON Center overview and endpoints][toncenter]
+- [API overview and public endpoints](/ecosystem/api/overview)
 - [AppKit documentation][appkit]
 
 ## Get support
@@ -301,5 +306,4 @@ Perform the following tests to validate UX and wallet behavior.
 Use the [sub-second finality support chat](https://t.me/subsecond_upgrade) for questions about this upgrade.
 
 [appkit]: /ecosystem/appkit/overview
-[toncenter]: /ecosystem/api/overview
 [streaming]: /ecosystem/api/toncenter/streaming/overview


### PR DESCRIPTION
Closes #2069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Sub-second finality declared live on mainnet (Apr 9, 2026) with updated integration and recommended-stack guidance
  * Requests vs. Streaming docs split; API comparison tables reorganized and reference links cleaned up
  * TonAPI Streaming API added as a compatible option alongside TON Center; endpoints and auth notes clarified
  * Self-hosting, streaming guidance, and throughput phrasing updated (indexer ~6.25x)
  * Corrected casing for “TonAPI” across docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->