### PR TITLE
fix(payments): correct block production time

### DIFF
--- a/payments/overview.mdx
+++ b/payments/overview.mdx
@@ -15,7 +15,7 @@ Off-chain processing monitors blockchain state changes from outside the network.
 
 TON achieves transaction [finality](https://en.wikipedia.org/wiki/Blockchain#Finality) after a single masterchain block confirmation, typically within 1 second. Once a transaction from a shardchain appears in a masterchain block, it becomes irreversible. This differs from blockchains like Ethereum where merchants wait for multiple confirmations (usually 12-15 blocks, taking 2-3 minutes) or Bitcoin where 6 confirmations are standard (about 60 minutes).
 
-The masterchain coordinates all workchain activity and produces blocks approximately every 1 second. When monitoring payments, you need to verify that the transaction was included in a masterchain block rather than just in a shardchain. Most TON APIs provide methods to check whether a transaction has achieved masterchain finality or, better yet, only consider transaction included in masterchain as finalized by the network.
+Since the [Catchain 2.0 update](/ecosystem/subsecond), the masterchain coordinates all workchain activity and produces blocks approximately every 400 milliseconds. When monitoring payments, you need to verify that the transaction was included in a masterchain block rather than just in a shardchain. Most TON APIs provide methods to check whether a transaction has achieved masterchain finality or, better yet, only consider a transaction included in the masterchain as finalized by the network.
 
 ## Supported assets
 

--- a/payments/overview.mdx
+++ b/payments/overview.mdx
@@ -13,9 +13,9 @@ Off-chain processing monitors blockchain state changes from outside the network.
 
 ## Transaction finality
 
-TON achieves transaction [finality](https://en.wikipedia.org/wiki/Blockchain#Finality) after a single masterchain block confirmation, typically within 5 seconds. Once a transaction from a shardchain appears in a masterchain block, it becomes irreversible. This differs from blockchains like Ethereum where merchants wait for multiple confirmations (usually 12-15 blocks, taking 2-3 minutes) or Bitcoin where 6 confirmations are standard (about 60 minutes).
+TON achieves transaction [finality](https://en.wikipedia.org/wiki/Blockchain#Finality) after a single masterchain block confirmation, typically within 1 second. Once a transaction from a shardchain appears in a masterchain block, it becomes irreversible. This differs from blockchains like Ethereum where merchants wait for multiple confirmations (usually 12-15 blocks, taking 2-3 minutes) or Bitcoin where 6 confirmations are standard (about 60 minutes).
 
-The masterchain coordinates all workchain activity and produces blocks approximately every 5 seconds. When monitoring payments, you need to verify that the transaction was included in a masterchain block rather than just in a shardchain. Most TON APIs provide methods to check whether a transaction has achieved masterchain finality or, better yet, only consider transaction included in masterchain as finalized by the network.
+The masterchain coordinates all workchain activity and produces blocks approximately every 1 second. When monitoring payments, you need to verify that the transaction was included in a masterchain block rather than just in a shardchain. Most TON APIs provide methods to check whether a transaction has achieved masterchain finality or, better yet, only consider transaction included in masterchain as finalized by the network.
 
 ## Supported assets
 


### PR DESCRIPTION
Following the latest update with the Catchan 2.0 consensus algorithm, TON has a block time of 400 ms. A transaction on the basechain is confirmed in 1 block and becomes final when the basechain block is confirmed by the masterchain (in the previous implementation, this took approximately 6 seconds; now the total time is less than a second).

_[2.1.12. Block generation intervals.](https://ton.org/whitepaper.pdf) We expect a new block to be generated in each shardchain and the masterchain approximately once every five seconds. This will lead to reasonably small transaction confirmation times. New blocks of all shardchains are generated approximately simultaneously; a new block of the masterchain is generated approximately one second later, because it must contain the hashes of the latest blocks of all shardchains._

TON uses sharding and, in the management of hypercube routing with a slow path (whitepaper 2.4.19), the relationship between the number of shardchains N and the number of steps required is ~log16(N) (this affects finality time logarithmically). At present, there are 16 shards and therefore only one step is required, meaning all shards are nearby.

Closes #1728.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated transaction finality guidance: transactions now typically finalize within 1 second (previously ~5 seconds).
  * Updated block production interval to ~400 ms and noted the Catchain 2.0 update.
  * Clarified payment monitoring guidance: verify transactions are included in a masterchain block and use TON APIs to check masterchain finality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->