### PR TITLE
chore(redirects): add redirects missing in the old docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1404,6 +1404,21 @@
       "permanent": true
     },
     {
+      "source": "/learn/overviews/ton-blockchain",
+      "destination": "/start-here",
+      "permanent": true
+    },
+    {
+      "source": "/learn/overviews/cells",
+      "destination": "/foundations/serialization/cells",
+      "permanent": true
+    },
+    {
+      "source": "/learn/overviews/addresses",
+      "destination": "/foundations/addresses/overview",
+      "permanent": true
+    },
+    {
       "source": "/learn/overviews/adnl",
       "destination": "https://old-docs.ton.org/learn/overviews/adnl",
       "permanent": true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "npx mint dev",
     "start:no-open": "mint dev --no-open",
     "check:openapi": "mint openapi-check ecosystem/api/toncenter/v2.json && mint openapi-check ecosystem/api/toncenter/v3.yaml",
-    "check:links": "mint broken-links",
+    "check:links": "mint broken-links --check-snippets",
     "check:redirects": "node scripts/check-redirects.mjs",
     "check:navigation": "node scripts/check-navigation.mjs",
     "check:fs": "echo 'https://github.com/ton-org/docs/issues/1182'",


### PR DESCRIPTION
Closes #2086

Found a couple related links and added redirects for them too. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added three permanent redirects so legacy documentation links automatically send users to the updated locations, preserving access to restructured content.

* **Chores**
  * Enhanced the link-check process to validate code snippets during broken-link checks, improving detection of invalid references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->