### PR TITLE
feat(tolk): additions and changes for Tolk v1.4 release

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -572,6 +572,7 @@
               "tolk/features/message-handling",
               "tolk/features/contract-storage",
               "tolk/features/contract-getters",
+              "tolk/features/contract-abi",
               "tolk/features/message-sending",
               "tolk/features/auto-serialization",
               "tolk/features/lazy-loading",

--- a/tolk/changelog.mdx
+++ b/tolk/changelog.mdx
@@ -2,6 +2,14 @@
 title: "Changelog"
 ---
 
+## [v1.4](https://github.com/ton-blockchain/ton/pull/2357)
+
+1. ABI export — for toolchain, explorers, UI
+1. TypeScript wrappers for Tolk contracts
+1. Source maps that map TVM execution back to Tolk source, variables, stack layout, and call frames
+1. Debugger marks that enable step-by-step debugging of fully-optimized production contracts
+1. Several language enhancements (continue the direction of a general-purpose language)
+
 ## [v1.3](https://github.com/ton-blockchain/ton/pull/2234)
 
 1. Introduced `array<T>` — dynamically sized arrays backed by TVM tuples.

--- a/tolk/features/contract-abi.mdx
+++ b/tolk/features/contract-abi.mdx
@@ -1,0 +1,167 @@
+---
+title: "Contract declaration and ABI"
+sidebarTitle: "Contract and ABI"
+---
+
+import { Aside } from '/snippets/aside.jsx';
+
+A Tolk file that defines a contract may start with a `contract` declaration. This is a directive for tooling: it tells the compiler that the file is a contract and lists the public shapes that describe it.
+
+The compiler uses this information to emit a machine-readable **ABI** — `out.abi.json` next to the produced `out.fif` — and to generate **TypeScript wrappers**, **source maps**, and other artifacts that the Acton toolchain consumes.
+
+```tolk
+contract Counter {
+    author: "My Team"
+    version: "0.1"
+    description: "A small counter contract"
+
+    storage: ContractStorage
+    incomingMessages: Increment | Reset
+}
+
+// the rest of the contract is unchanged:
+// types, onInternalMessage, get methods, etc.
+```
+
+<Aside type="note">
+  The directive does not affect bytecode at all. Contracts work without it just as before; declaring `contract` is what enables ABI export and tooling integration.
+</Aside>
+
+## What the `contract` declaration affects
+
+By convention, the file's name matches the contract's name (preferably PascalCase): `JettonMinter.tolk`, `JettonWallet.tolk`. Adding the declaration:
+
+- lists the contract's public interface in one place;
+- enables ABI export and TypeScript wrappers;
+- changes how [imports](/languages/tolk/syntax/imports) propagate entrypoints (see below);
+- requires all `get fun` and message entrypoints to live in the same file.
+
+### Entrypoints must be in the same file
+
+When `contract` is present, all entrypoints (`get fun`, `onInternalMessage`, `onExternalMessage`) declarations must exist in the same file. They cannot be imported from another file — the compiler reports an error if you try.
+
+```tolk
+// file: MyContract.tolk
+import "separate-getter"   // compilation error if it declares `get fun`
+
+contract MyContract { /* ... */ }
+```
+
+### Imports do not pollute entrypoints
+
+When file `Foo.tolk` declares `contract Foo`, then `import "Foo"` exposes its types, functions, and methods, but **not** its `onInternalMessage` and `get fun`. Those belong to `Foo` only.
+
+This enables two patterns:
+
+1. **Tests and scripts as standalone files.** Import a contract and add your own `get fun` for tests — no conflicts.
+1. **Multi-contract projects.** A jetton minter can `import "JettonWallet"` to reuse its types (`WalletStorage`, messages) without colliding on `onInternalMessage` or get methods.
+
+## Properties of `contract`
+
+Most properties either describe the contract for explorers and clients, or expose information the compiler can not infer from imperative code (such as which messages are accepted). All properties are optional except those required for ABI fidelity in your case.
+
+```tolk
+contract SomeName {
+    /// arbitrary metadata strings, exported to ABI as-is
+    author: "Tolk team"
+    version: "1.0"
+    description: "..."
+
+    /// shape of persistent on-chain data
+    storage: MyStorage
+
+    /// shape of storage AT DEPLOYMENT (when calculating
+    /// initial address), if it differs from `storage`;
+    /// for example, NFT items have a smaller pre-init shape
+    storageAtDeployment: PartialStruct
+
+    /// internal messages accepted by this contract;
+    /// typically the same union used in `lazy` match
+    incomingMessages: UnionOfStructs
+
+    /// expected shape for `onExternalMessage`, if present
+    incomingExternal: SomeStructOrUnion
+
+    /// outgoing internal messages and emitted events;
+    /// auto-derived from `createMessage` /
+    /// `createExternalLogMessage` calls — specify only to override
+    outgoingMessages: UnionOfStructs
+    emittedEvents: UnionOfStructs
+
+    /// exception codes the contract may throw (an enum);
+    /// auto-derived from `throw` / `assert` — specify to override
+    thrownErrors: SomeEnum
+
+    /// extra types to include in ABI even if unreachable
+    /// from storage/messages/getters (handy for unit tests)
+    forceAbiExport: (type1, type2, ...)
+}
+```
+
+`incomingMessages` and `storage` cannot be inferred from source — Tolk treats `MyStorage` as a regular struct and `lazy ... fromSlice` as one of many ways to dispatch a body. The compiler asks you to declare them explicitly to make ABI honest and stable.
+
+## Contract ABI export
+
+Invoked from the command line:
+
+```bash
+tolk -o out.fif Counter.tolk
+```
+
+The compiler produces `out.abi.json` next to `out.fif`. The ABI contains:
+
+- contract metadata (name, author, version, description);
+- incoming and outgoing internal messages, external messages, emitted events;
+- storage shape (and storage at deployment, if any);
+- get methods with parameters and return types;
+- exceptions the contract may throw;
+- user-defined declarations (structs, aliases, enums) and the unique types they reference;
+- compiler name and version.
+
+The ABI is targeted at machine consumption: it powers TypeScript wrappers, explorers, UI builders, dynamic serialization, stack-layout introspection, and other client-side tooling. Tolk's ABI is built on the Tolk type system, not TL-B — Tolk types are richer than TL-B (aliases, enums, inline unions with auto-generated prefix trees, custom serializers, and so on).
+
+### Doc comments
+
+Place `///` doc comments above declarations to enrich ABI with descriptions. They are then surfaced as comments in TypeScript wrappers, IDE hover, explorer UIs, and so on.
+
+```tolk
+/// Persistent contract data
+struct (0x12345678) ContractStorage {
+    /// Current counter value
+    counter: int32
+
+    /// Contract owner
+    owner: address
+}
+
+/// Reads current counter.
+/// @param verbose whether to include debug info
+get fun currentCounter(verbose: bool): (int32, cell?) {
+    // ...
+}
+
+enum ErrCode {
+    /// Sender is not allowed to perform this action.
+    NotOwner = 401
+}
+```
+
+Only `///` comments are treated as documentation. Regular `//` comments inside code are ignored.
+
+### Client-side type override
+
+Sometimes the on-chain field is intentionally low-level (to save gas), but client tools should see a richer shape. Use the `@abi.clientType` annotation to expose a different type to ABI:
+
+```tolk
+struct AskToTransfer {
+    // ...
+    @abi.clientType(PayloadInline | PayloadInRef)
+    forwardPayload: RemainingBitsAndRefs
+}
+```
+
+The compiler still serializes the field as `RemainingBitsAndRefs`, but ABI advertises the richer union to clients.
+
+### Describing existing FunC contracts
+
+To generate TypeScript wrappers (or any ABI-driven artifact) for an existing FunC contract, **describe its interface in Tolk** rather than hand-writing JSON. A skeleton with the contract declaration, type stubs, and an empty `onInternalMessage` is enough for the compiler to emit a complete ABI.

--- a/tolk/features/contract-getters.mdx
+++ b/tolk/features/contract-getters.mdx
@@ -31,6 +31,19 @@ Use camelCase for naming.
 This convention may be overridden when matching standard TEPs. For example, a jetton wallet should expose a method `get_wallet_data`, as it was named in implementations.
 In such cases, using `get fun get_wallet_data` is appropriate, even if it does not follow the camelCase convention.
 
+## Documentation comments
+
+Place `///` doc comments above a get method to enrich the [exported ABI](/languages/tolk/features/contract-abi#doc-comments) with descriptions.
+They are surfaced in TypeScript wrappers, IDE hover, explorers, and other client-side tooling.
+
+```tolk
+/// Reads current counter.
+/// @param verbose whether to include debug info
+get fun currentCounter(verbose: bool): SomeReply {
+    // ...
+}
+```
+
 ## Structures
 
 When a getter returns multiple values, define a [structure](/languages/tolk/types/structures) and return it.

--- a/tolk/features/contract-storage.mdx
+++ b/tolk/features/contract-storage.mdx
@@ -100,6 +100,16 @@ This behavior is not related to [nullable types](/languages/tolk/types/nullable)
 
 This pattern is common in NFT contracts. Initially, an NFT contains only `itemIndex` and `collectionAddress`. After initialization, `ownerAddress` and `content` are added to the storage.
 
+When this pattern is used, declare both shapes in the [`contract` declaration](/languages/tolk/features/contract-abi) so client tools can compute the deployment address correctly:
+
+```tolk
+contract NftItem {
+    storage: NftItemStorage
+    storageAtDeployment: NftItemStorageNotInitialized
+    // ...
+}
+```
+
 Since arbitrary imperative code is allowed, the approach is:
 
 - Define two structures: initialized and uninitialized storages.

--- a/tolk/features/jetton-payload.mdx
+++ b/tolk/features/jetton-payload.mdx
@@ -146,7 +146,7 @@ fun createRefPayload(ref: cell) {
     // but like this: '1' + ref
     val payload = beginCell()
             .storeBool(true).storeRef(ref)
-            .asSlice();
+            .toSlice();
 }
 ```
 

--- a/tolk/features/message-handling.mdx
+++ b/tolk/features/message-handling.mdx
@@ -4,6 +4,8 @@ title: "Handling messages"
 
 Each Tolk contract has special entrypoints – reserved functions that handle different message types. Handling an incoming message uses ordinary language constructs.
 
+A contract file typically begins with a [`contract` declaration](/languages/tolk/features/contract-abi) that names the contract and lists its public shapes — including the union of incoming messages.
+
 ## `onInternalMessage`
 
 Contracts primarily handle [internal messages](/foundations/messages/internal#internal-messages). Users interact with contracts through their wallets, which send internal messages to the contract. The entrypoint is declared as follows:
@@ -18,6 +20,7 @@ The basic guidelines are:
 
 - For each incoming message, declare a `struct` with a unique 32-bit prefix, opcode.
 - Declare a union type that represents all supported messages.
+- Reference the union from `incomingMessages:` in the [`contract` declaration](/languages/tolk/features/contract-abi).
 - Parse this union from `in.body` and `match` over structures.
 
 ```tolk
@@ -30,6 +33,11 @@ struct (0x23456789) CounterReset {
 }
 
 type AllowedMessage = CounterIncrement | CounterReset
+
+contract Counter {
+    storage: Storage
+    incomingMessages: AllowedMessage
+}
 
 fun onInternalMessage(in: InMessage) {
     val msg = lazy AllowedMessage.fromSlice(in.body);
@@ -227,7 +235,7 @@ When a contract accepts an external message, it has limited gas for execution. A
 
 Tolk defines several reserved entrypoints:
 
-- `fun onTickTock` is invoked on tick-tock transactions;
+- `fun onRunTickTock` is invoked on tick-tock transactions;
 - `fun onSplitPrepare` and `fun onSplitInstall` are reserved for split and install transactions; currently not used by the blockchain;
 - `fun main` is used for simple snippets and demos.
 

--- a/tolk/from-func/tolk-vs-func.mdx
+++ b/tolk/from-func/tolk-vs-func.mdx
@@ -93,7 +93,7 @@ get fun publicKey() {
 ### Boolean type
 
 - FunC represents only integers: `-1` for true, `0` for false; `ifnot`.
-- Tolk provides a [`bool` type](/languages/tolk/types/booleans) and logical operators `&&`, `||`, and `!`.
+- Tolk provides a [`bool` type](/languages/tolk/types/booleans) and logical operators `&&`, `||`, and `!`. Conditions of `if`, `while`, ternary, and `assert` must be `bool` — write `if (someInt != 0)` instead of `if (someInt)`.
 
 ```tolk
 if (trustInput || validate(input)) {
@@ -394,3 +394,8 @@ Although Tolk is a high-level language, it exposes [low-level capabilities](/lan
 fun incThenNegate(v: int): int
     asm "INC" "NEGATE"
 ```
+
+### ABI, TypeScript wrappers, and a debugger
+
+- FunC has no machine-readable interface description — clients hand-roll wrappers and rely on heuristics.
+- Tolk emits an [ABI JSON](/languages/tolk/features/contract-abi#contract-abi-export) directly from sources whenever a file declares a `contract { ... }`. The same metadata drives auto-generated TypeScript wrappers, source maps, and a step-by-step debugger that works on fully-optimized bytecode.

--- a/tolk/idioms-conventions.mdx
+++ b/tolk/idioms-conventions.mdx
@@ -6,6 +6,19 @@ import { Aside } from '/snippets/aside.jsx';
 
 After learning of [basic syntax](/languages/tolk/basic-syntax), study the common patterns, conventions, and best practices to write idiomatic Tolk code.
 
+## Declare each contract with a `contract` directive
+
+Place a [`contract` declaration](/languages/tolk/features/contract-abi) at the top of every entrypoint file. It names the contract and lists its public shapes — at minimum, the storage struct and the union of accepted incoming messages. The compiler uses this information to emit a machine-readable ABI, which in turn powers TypeScript wrappers, explorers, the step-by-step debugger, and other client-side tooling.
+
+```tolk
+contract JettonWallet {
+    storage: WalletStorage
+    incomingMessages: WalletMessages
+}
+```
+
+Use the contract's PascalCase name as the file name: `JettonWallet.tolk`, `JettonMinter.tolk`. All `get fun` and entrypoints must live in the same file as the `contract` declaration.
+
 ## Prefer automatic serialization to manual one
 
 Manual work with slices and builders is error-prone and tedious. By comparison, [auto-serialization](/languages/tolk/features/auto-serialization) with structures helps express data with types and prevents many related bugs.
@@ -183,6 +196,11 @@ struct (0x23456789) CounterReset {
 }
 
 type AllowedMessage = CounterIncrement | CounterReset
+
+contract Counter {
+    storage: Storage
+    incomingMessages: AllowedMessage
+}
 
 fun onInternalMessage(in: InMessage) {
     val msg = lazy AllowedMessage.fromSlice(in.body);
@@ -367,9 +385,9 @@ Consistent file structure across projects simplifies navigation:
 - Supply `errors.tolk` with constants or enums.
 - Supply `storage.tolk` with storage and helper methods.
 - Supply `messages.tolk` with incoming and outgoing messages.
-- Have `some-contract.tolk` as an entrypoint. Keep entrypoint files minimal, use [imports](/languages/tolk/syntax/imports) to bring all supplementary code.
+- Have `MyContract.tolk` as an entrypoint, named after the contract in PascalCase. Place a [`contract` declaration](/languages/tolk/features/contract-abi) at the top of the file and keep all `get fun` and entrypoint functions within it; use [imports](/languages/tolk/syntax/imports) to bring in shared code.
 
-When developing several related contracts simultaneously, keep them in the same codebase. For instance, struct `SomeMessage`, outgoing for contract A, can be incoming for contract B. In other cases,  contract A must know B's storage to assign the initial state for deployment.
+When developing several related contracts simultaneously, keep them in the same codebase. A contract file can `import` another contract — its types are exposed to the importer, while its `onInternalMessage` and `get fun` stay private to the original contract. For instance, struct `SomeMessage` outgoing for contract A can be incoming for contract B; or contract A may need to know B's storage to compute the deploy address.
 
 ## Prefer methods to functions
 

--- a/tolk/overview.mdx
+++ b/tolk/overview.mdx
@@ -10,6 +10,11 @@ The language compiles to [TVM](/tvm/overview) and provides direct control over e
 ```tolk
 type AllowedMessage = CounterIncrement | CounterReset
 
+contract Counter {
+    storage: Storage
+    incomingMessages: AllowedMessage
+}
+
 fun onInternalMessage(in: InMessage) {
     val msg = lazy AllowedMessage.fromSlice(in.body);
     match (msg) {
@@ -33,6 +38,7 @@ Tolk provides high-level readability while preserving low-level control:
 - a type system for describing [cell](/foundations/serialization/cells) layouts;
 - [`lazy` loading](/languages/tolk/features/lazy-loading) that skips unused fields;
 - unified message composition and deployment;
+- a [`contract` declaration](/languages/tolk/features/contract-abi) that drives ABI export, TypeScript wrappers, source maps, and debugging;
 - a compiler targeting the Fift assembler;
 - tooling with IDE integration.
 

--- a/tolk/syntax/conditions-loops.mdx
+++ b/tolk/syntax/conditions-loops.mdx
@@ -19,13 +19,15 @@ if (condition) {
 }
 ```
 
-A condition must be a boolean or an integer. If not equals 0, then `true`:
+A condition must be a [`bool`](/languages/tolk/types/booleans). Integers are not implicitly converted — write the comparison explicitly:
 
 ```tolk
-if (someInt) {     // means "someInt != 0"
+if (someInt != 0) {
     // ...
 }
 ```
+
+The same rule applies to `while`, `do while`, ternary, [`assert`](/languages/tolk/syntax/exceptions#assert-statement), and the unary `!` operator. There is no gas overhead — the compiler strips the `!= 0` comparison off whenever it would translate to a redundant TVM instruction.
 
 The body of `if` and `else` must be enclosed in `{ ... }`:
 
@@ -141,6 +143,15 @@ fun demoDoWhile() {
     } while (rand % 2 == 0);
     return rand;  // an odd number
 }
+```
+
+Variables declared inside the body of `do while` are not visible in its condition. Declare them before the loop:
+
+```tolk
+var found: bool;
+do {
+    found = ...
+} while (found);
 ```
 
 `while` is used to iterate over maps:

--- a/tolk/syntax/exceptions.mdx
+++ b/tolk/syntax/exceptions.mdx
@@ -66,7 +66,7 @@ assert (msg.validUntil > blockchain.now()) throw E_EXPIRED;
 - The long form `assert (condition) throw ERR_CODE` is preferred.
 - The short form `assert (condition, ERR_CODE)` exists but is not recommended.
 
-The `condition` must be either a boolean or an integer, where non-zero integers are treated as `true` and all other integer values as `false`.
+The `condition` must be a [`bool`](/languages/tolk/types/booleans). Integers are not implicitly converted: use `assert (someInt != 0)` instead of `assert (someInt)`.
 
 An `assert` statement is equivalent to:
 
@@ -100,7 +100,7 @@ try {
 ```
 
 - Use the short form `catch { ... }` when `errCode` is not needed.
-- Use the long form `catch (errCode, arg)` when the exception may carry an argument produced by `throw (errCode, arg)`. The `arg` is of type `unknown`; use `as` to cast it. If the exception was thrown as `throw errCode`, the argument is `null`.
+- Use the long form `catch (errCode, arg)` when the exception may carry an argument produced by `throw (errCode, arg)`. The `arg` is of type `unknown`; use `as` to cast it. If the exception was thrown as `throw errCode`, the argument is `0`.
 
 ```tolk
 try {

--- a/tolk/syntax/functions-methods.mdx
+++ b/tolk/syntax/functions-methods.mdx
@@ -60,6 +60,22 @@ fun demo() {
 }
 ```
 
+### Optional `void` parameters
+
+If a trailing parameter has type `void`, it may be omitted at the call site. This is especially convenient for generic helpers where "no argument" is naturally expressed as `void`, instead of using a nullable wrapper or a pile of overloads.
+
+```tolk
+fun format<T1 = void, T2 = void>(msg: string, arg1: T1, arg2: T2) {
+    // ...
+}
+
+format("hello");
+format("value is {}", 42);
+format("pair is {} and {}", "str", beginCell());
+```
+
+The same convention has long been allowed for [`void`-typed struct fields](/languages/tolk/types/void-never#void-typed-fields).
+
 ## Method declaration
 
 Methods are declared as extension functions with a receiver specified before the name:
@@ -466,3 +482,5 @@ fun demo() {
     })
 }
 ```
+
+Lambdas can capture outer variables by value, becoming [closures](/languages/tolk/types/callables#closures-lambdas-with-captures).

--- a/tolk/syntax/imports.mdx
+++ b/tolk/syntax/imports.mdx
@@ -50,16 +50,17 @@ Techniques to avoid name collisions:
 
 ## Repeated symbols across contracts
 
-When developing multiple contracts, each contract has its own file, compilation target. Contract files do not import one another; therefore, the following declarations do not conflict across different contracts:
-
-- `onInternalMessage` and `onExternalMessage`;
-- `get fun`;
-- other contract entrypoints.
+When developing multiple contracts, each contract has its own file and compilation target. Place a [`contract` declaration](/languages/tolk/features/contract-abi) in every entrypoint file:
 
 ```tolk
-// file: a-contract.tolk
+// file: ContractA.tolk
 import "storage"
 import "errors"
+
+contract ContractA {
+    storage: StorageA
+    incomingMessages: MsgsA
+}
 
 fun onInternalMessage(in: InMessage) {
     // ...
@@ -71,9 +72,15 @@ get fun name() {
 ```
 
 ```tolk
-// file: b-contract.tolk
+// file: ContractB.tolk
 import "storage"
 import "errors"
+import "ContractA"   // brings types from ContractA, but NOT its entrypoints
+
+contract ContractB {
+    storage: StorageB
+    incomingMessages: MsgsB
+}
 
 fun onInternalMessage(in: InMessage) {
     // ...
@@ -84,19 +91,17 @@ get fun name() {
 }
 ```
 
-Get methods conceptually belong to the scope of a specific contract.
+`onInternalMessage`, `onExternalMessage`, and `get fun` belong to a specific contract. When a file declares `contract`, importing it exposes its types and functions but **not** these entrypoints — so `ContractB` can reuse `ContractA`'s storage and messages without any naming conflicts on `onInternalMessage` or get methods.
+
+In addition, when `contract` is present, all entrypoints must live in the same file as the `contract` declaration; importing a file that declares a `get fun` is not allowed.
 
 In a multi-contract project, each contract file typically contains only:
 
+- its `contract` declaration,
 - its entrypoints,
-- optionally, a union of allowed messages,
 - and contract-specific logic.
 
-The remaining codebase is shared.
-
-For instance, a struct `SomeMessage` outgoing for one contract and incoming for another. When one contract deploys another, both must share the storage struct.
-
-As a guideline, group messages, errors, utils, etc. in shared files, and use only minimal declarations inside each `contract.tolk`.
+The remaining codebase — messages, errors, utils, shared storage structs — is split into supplementary files that every contract may `import`.
 
 ## Import path mappings
 

--- a/tolk/syntax/operators.mdx
+++ b/tolk/syntax/operators.mdx
@@ -26,7 +26,7 @@ Skips the [nullability](/languages/tolk/types/nullable) check: `someVar!`.
 
 ### Unary operators `!` `~` `-` `+`
 
-[Logical negation](/languages/tolk/types/booleans) `!x`, bitwise not `~x`, unary `-x` and `+x`.
+[Logical negation](/languages/tolk/types/booleans) `!x` (requires a `bool`), bitwise not `~x`, unary `-x` and `+x`.
 
 ### Operators `as` `is` `!is`
 
@@ -64,7 +64,7 @@ Assignment and augmented assignments.
 
 Returns the left operand if it is not `null`; otherwise, evaluates and returns the right operand. See [nullable types](/languages/tolk/types/nullable#null-coalescing-operator).
 
-### Ternary `... ? ... : ...`
+### Ternary `... ? ... : ...` (same priority)
 
 Ternary expressions are available in [conditions](/languages/tolk/syntax/conditions-loops).
 

--- a/tolk/types/booleans.mdx
+++ b/tolk/types/booleans.mdx
@@ -21,18 +21,18 @@ var valid = isSignatureValid(...);    // bool
 var end = someSlice.isEmpty();        // bool
 ```
 
-## Logical operators accept both `int` and `bool`
+## Conditions and logical operators require `bool`
 
-- Operator `!x` supports both `bool` and `int`.
-- The condition of `if` and similar statements accepts both `bool` and `int`, where it treats the latter as `true` if the value is not equal to 0, and as `false` otherwise.
-- Logical operators `&&` and `||` accept both `bool` and `int`. For example, `a && b` evaluates to `true` when both operands are `true` or both operands are non-zero integers.
+- The condition of `if`, `while`, `do while`, ternary, and `assert` must be a `bool`. Integers are not implicitly converted: write `if (x != 0)` rather than `if (x)`.
+- The unary `!` operator requires a `bool`: write `if (x == 0)` rather than `if (!x)`.
+- Logical operators `&&` and `||` short-circuit and accept both `bool` and `int` operands.
 
 Arithmetic operators are restricted to integers.
 
 ```tolk
 valid && end;  // ok
 valid & end;   // ok, bitwise & | ^ also work if both are bools
-if (!end)      // ok
+if (!end)      // ok, end is bool
 
 valid + end;   // error
 8 & valid;     // error, int & bool not allowed

--- a/tolk/types/callables.mdx
+++ b/tolk/types/callables.mdx
@@ -96,15 +96,39 @@ fun HasCallback<TResult>.invoke(self): TResult {
 }
 ```
 
-Lambdas are not closures. Capturing variables from an outer scope is not supported:
+## Closures (lambdas with captures)
+
+Lambdas capture outer variables, becoming first-class closures:
 
 ```tolk
-fun outer(x: int) {
-    return fun(y: int) {
-        return x + y;    // error: undefined symbol `x`
-    }
+fun makeAdder(delta: int): int -> int {
+    return fun(value) {
+        return value + delta;
+    };
+}
+
+fun demo() {
+    val add3 = makeAdder(3);
+    return add3(10);   // 13
 }
 ```
+
+There is no special `use` or `[&]` syntax — capturing happens automatically. Variables are captured **by value at the point where the lambda is created**, so later mutations of the outer variable do not propagate into the closure:
+
+```tolk
+fun demo() {
+    var x = 10;
+
+    val cb = fun() {
+        return x + 1;
+    };
+
+    x = 20;
+    return cb();   // 11, not 21
+}
+```
+
+Closures combine with generics, nesting, and smart casts: a lambda captures the narrowed type of a variable as of the point where it was created.
 
 ## Low-level TVM continuations
 

--- a/tolk/types/cells.mdx
+++ b/tolk/types/cells.mdx
@@ -160,7 +160,7 @@ val c = beginCell()
 The only way to access bits already written to a builder is to convert it into a slice:
 
 ```tolk
-var s = b.asSlice();
+var s = b.toSlice();
 // or (exactly the same)
 var s = b.endCell().beginParse();
 ```

--- a/tolk/types/enums.mdx
+++ b/tolk/types/enums.mdx
@@ -112,6 +112,17 @@ At the TVM level, every enum is represented as `int`. Casting between the enum a
 
 During deserialization with `fromCell()`, the compiler validates that encoded integers correspond to valid enum values.
 
+### Enums are assignable to integers
+
+Enums are distinct types, but enum values can be assigned to `int` (and `intN`) variables without an explicit `as` cast:
+
+```tolk
+var x: int = Color.Red;
+var y: int32 = VmExitCode.OutOfGasError;
+```
+
+This is most useful for enums that represent TVM exit codes, operation ids, modes, and other numeric constants.
+
 ## Usage in `throw` and `assert`
 
 Enums are allowed in `throw` and `assert`:

--- a/tolk/types/numbers.mdx
+++ b/tolk/types/numbers.mdx
@@ -48,6 +48,16 @@ const MAX_UINT8 = 0xFF;
 const MAX_INT = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
 ```
 
+### Numeric separators
+
+Integer literals may contain `_` separators to improve readability. They are ignored by the compiler.
+
+```tolk
+const A = 1_000_000;
+const B = 0x_ABCD_EF01;
+const C = 0b_1010_1011_0000;
+```
+
 ## First-class types
 
 All integer types can be nullable, combined within a union, and otherwise used in structural or multi-valued types:

--- a/tolk/types/overall-serialization.mdx
+++ b/tolk/types/overall-serialization.mdx
@@ -344,6 +344,36 @@ struct WithUnion {
 }
 ```
 
+### `void` as a union variant — empty slice
+
+A union variant of type `void` has no representation on the wire — it's matched by an empty slice (zero bits, zero refs). The other variants form a normal prefix tree among themselves and are unaffected.
+
+```tolk
+struct (0x01) Some { x: int32 }
+
+// either Some (0x01 + int32) — or empty slice
+type SomeOrEnd = Some | void
+
+// either 32 bits — or empty slice
+type Int32OrEnd = int32 | void
+
+// 0+int32, 1+int64, or empty slice
+type WideOrEnd = int32 | int64 | void
+```
+
+- On pack: writing the `void` variant emits **nothing**.
+- On unpack: when the input slice is empty, the deserialized value is the `void` variant; otherwise, normal prefix-tree dispatch is used.
+- `void` must be the **last** variant of a serializable union (otherwise the prefix dispatch would be ambiguous); the compiler enforces this when generating opcodes.
+
+In `match`, the `void` arm is written as `void => ...`:
+
+```tolk
+match (msg) {
+    Some => { /* read Some.x */ }
+    void => { /* slice was empty */ }
+}
+```
+
 ## Tensors `(T1, T2, ...)`
 
 Tensor components are serialized sequentially, akin to `struct` fields.

--- a/tolk/types/type-checks-and-casts.mdx
+++ b/tolk/types/type-checks-and-casts.mdx
@@ -79,7 +79,7 @@ fun analyzeStorage(nCells: int, lastCell: cell?) {
     // Say, according to the logic of this program,
     // having non-zero number of `nCells` must mean
     // that the `lastCell` is not `null`
-    if (nCells) {
+    if (nCells != 0) {
         // Therefore, one can explicitly instruct
         // the compiler to recognize that fact
         doSmth(lastCell!);

--- a/tolk/types/unions.mdx
+++ b/tolk/types/unions.mdx
@@ -150,6 +150,10 @@ This pattern is referred to as [`lazy` match](/languages/tolk/features/lazy-load
 
 Union types continue to work correctly without `lazy` and follow the same type-system rules.
 
+## `void` as a union variant
+
+`T | void` is a valid serializable union meaning "T or empty slice" — `void` carries no bits and does not participate in the prefix tree. This is useful for chains like wallet-v5's payload format: parse cells until refs run out. See [void-never](/languages/tolk/types/void-never#void-inside-unions-for-serialization).
+
 ## Stack layout and serialization
 
 Union types have a complex [stack layout](/languages/tolk/types/overall-tvm-stack), commonly referred to as tagged unions.

--- a/tolk/types/void-never.mdx
+++ b/tolk/types/void-never.mdx
@@ -51,6 +51,43 @@ fun demo() {
 }
 ```
 
+### Optional `void` parameters
+
+The same convention applies to function parameters: a trailing `void` parameter may be omitted at the call site. This is convenient for generic helpers where "no argument" is naturally represented by `void`.
+
+```tolk
+fun format<T1 = void, T2 = void>(msg: string, arg1: T1, arg2: T2) {
+    // ...
+}
+
+format("hello");
+format("value is {}", 42);
+format("pair is {} and {}", "str", beginCell());
+```
+
+For example, `body` of `createMessage` can be omitted because its type defaults to `TBody = void`.
+
+### `void` inside unions for serialization
+
+`T | void` is a valid serializable union. On the wire, `void` means **empty slice**: nothing is written on serialization, and an empty input slice deserializes to the `void` variant.
+
+This expresses "T or zero bits" — different from `T | null`, which always emits at least the `Maybe` bit.
+
+```tolk
+struct (0x01) Some { x: int32 }
+
+// either Some (0x01 + int32) — or empty slice
+type SomeOrEnd = Some | void
+
+// either 32 bits — or empty slice
+type Int32OrEnd = int32 | void
+
+// 0+int32, 1+int64, or empty slice
+type WideOrEnd = int32 | int64 | void
+```
+
+`void` does not participate in the prefix tree built for the other variants; it must come last and is matched by an empty slice. After deserialization, the value can be tested with `someVar is void`, or with `match (v) { ... void => ... }`. See [serialization rules](/languages/tolk/types/overall-serialization#void-as-a-union-variant-empty-slice) for details.
+
 ## `never`
 
 A function that never returns is `never`. A function whose execution always terminates by throwing an error has return type `never`:


### PR DESCRIPTION
Tolk v1.4 is releasing here:
* https://github.com/ton-blockchain/ton/pull/2357

Brief changelog:

1. ABI export — for toolchain, explorers, UI
1. TypeScript wrappers for Tolk contracts
1. Source maps that map TVM execution back to Tolk source, variables, stack layout, and call frames
1. Debugger marks that enable step-by-step debugging of fully-optimized production contracts
1. Several language enhancements (continue the direction of a general-purpose language)

This PR fully reflects all the changes and removes information that becomes outdated.

Changelog: https://github.com/ton-blockchain/ton/pull/2357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contract ABI docs (generation, tooling, ABI properties, doc-comment integration) and a v1.4 changelog
  * Expanded guidance: message handling, storage-migration pattern, imports/contract organization, entrypoint conventions, and contract getters docs
  * Clarified language rules: boolean-only conditions, do-while scoping, unary `!`, closures, `void` in unions/params, numeric separators, enums→int

* **Bug Fixes**
  * Updated code examples to use the correct slice conversion method and renamed a reserved entrypoint example

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ton-org/docs/pull/2150)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->