### PR TITLE
fix(nodes): update validator clang requirements

### DIFF
--- a/ecosystem/nodes/cpp/run-validator.mdx
+++ b/ecosystem/nodes/cpp/run-validator.mdx
@@ -42,7 +42,7 @@ This guide explains how to run a validator TON node with MyTonCtrl from scratch.
 
 - Ubuntu 22.04 LTS or 24.04 LTS
 - Python 3.10 or higher
-- Clang 16.0.0 or higher
+- Clang 21.0.0 or higher
 
 ```bash
 # Check Ubuntu version
@@ -71,22 +71,24 @@ clang --version
   ```bash
   # Check Clang version
   clang --version
-  # If version 16, skip the steps below.
+  # If version 21, skip the steps below.
 
-  # Required for Ubuntu 22.04. Update current Clang to clang-16
-  sudo apt update
-  sudo apt install -y lsb-release wget software-properties-common gnupg
-  sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+  # Ubuntu 22.04
+  sudo apt install lsb-release wget software-properties-common gnupg
   wget https://apt.llvm.org/llvm.sh
   chmod +x llvm.sh
-  sudo ./llvm.sh 16 clang
+  sudo ./llvm.sh 21 clang
 
-  # Change default Clang
-  sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 100
-  sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 100
+  # Ubuntu 24.04
+  wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+  echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+  sudo apt -y update
+  sudo apt install -y clang-21
 
-  # Required for Ubuntu 24.04. Install clang-16
-  sudo apt install -y clang-16
+  # optionally, change default clang
+  sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-21 200
+  sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 200
+
 
   ```
 </Accordion>

--- a/ecosystem/nodes/cpp/run-validator.mdx
+++ b/ecosystem/nodes/cpp/run-validator.mdx
@@ -40,22 +40,13 @@ This guide explains how to run a validator TON node with MyTonCtrl from scratch.
 
 ### 1.3 Software requirements
 
-- Ubuntu 22.04 LTS or 24.04 LTS
-- Python 3.10 or higher
-- Clang 21.0.0 or higher
+- Ubuntu 22.04 LTS or 24.04 LTS: check with `cat /etc/os-release`
+- Python 3.10 or higher: check with `python3 --version`
+- Clang 21.0.0 or higher: check with `clang --version`
 
 ```bash
-# Check Ubuntu version
 cat /etc/os-release
-```
-
-```bash
-# Check Python version
 python3 --version
-```
-
-```bash
-# Check Clang version
 clang --version
 ```
 
@@ -68,28 +59,29 @@ clang --version
 <Accordion
   title="Update Clang..."
 >
+  If running `clang --version` shows a version of 21 or higher, skip the steps below.
+
+  <CodeGroup>
+    ```bash title="Ubuntu 22.04"
+    sudo apt install lsb-release wget software-properties-common gnupg
+    wget https://apt.llvm.org/llvm.sh
+    chmod +x llvm.sh
+    sudo ./llvm.sh 21 clang
+    ```
+
+    ```bash title="Ubuntu 24.04"
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/llvm-snapshot.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+    sudo apt -y update
+    sudo apt install -y clang-21
+    ```
+  </CodeGroup>
+
+  Update the default `clang` in the system:
+
   ```bash
-  # Check Clang version
-  clang --version
-  # If version 21, skip the steps below.
-
-  # Ubuntu 22.04
-  sudo apt install lsb-release wget software-properties-common gnupg
-  wget https://apt.llvm.org/llvm.sh
-  chmod +x llvm.sh
-  sudo ./llvm.sh 21 clang
-
-  # Ubuntu 24.04
-  wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-  echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-  sudo apt -y update
-  sudo apt install -y clang-21
-
-  # optionally, change default clang
   sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-21 200
   sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 200
-
-
   ```
 </Accordion>
 


### PR DESCRIPTION
Closes https://github.com/ton-org/docs/issues/2084.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Clang version requirement from 16.0.0 to 21.0.0 or higher for validator setup
  * Revised upgrade guide with steps for Ubuntu 22.04 and 24.04 systems

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ton-org/docs/pull/2158)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->