### PR TITLE
feat(internal-infra): add 180-day stale workflow for issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,7 @@ name: Close stale issues and PRs
 on:
   schedule:
     - cron: '30 1 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-stale
@@ -20,15 +21,19 @@ jobs:
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          start-date: '2026-01-01T00:00:00Z' # since January 1st
+          # Intentionally limited to items created on or after January 1st
+          # to avoid closing some important older issues and PRs:
+          start-date: '2026-01-01T00:00:00Z'
           stale-issue-message: >
             This issue is deemed stale because it has been open 6 months (180 days) with no recent activity.
-            Remove stale label or make a comment. Otherwise, this PR will be closed in 5 days.
+            Remove stale label or make a comment. Otherwise, this issue will be closed in 5 days.
           stale-pr-message: >
             This PR is deemed stale because it has been open 6 months (180 days) with no recent activity.
             Remove stale label, then make a comment or push a new commit. Otherwise, this PR will be closed in 5 days.
           stale-issue-label: stale
           stale-pr-label: stale
+          close-issue-reason: not_planned
           days-before-stale: 180
           days-before-close: 5
           exempt-issue-labels: 'backlog,kind: bug,from-old-docs'
+          exempt-pr-labels: 'backlog,kind: bug,from-old-docs'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-stale
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          start-date: '2026-01-01T00:00:00Z' # since January 1st
+          stale-issue-message: >
+            This issue is deemed stale because it has been open 6 months (180 days) with no recent activity.
+            Remove stale label or make a comment. Otherwise, this PR will be closed in 5 days.
+          stale-pr-message: >
+            This PR is deemed stale because it has been open 6 months (180 days) with no recent activity.
+            Remove stale label, then make a comment or push a new commit. Otherwise, this PR will be closed in 5 days.
+          stale-issue-label: stale
+          stale-pr-label: stale
+          days-before-stale: 180
+          days-before-close: 5
+          exempt-issue-labels: 'backlog,kind: bug,from-old-docs'


### PR DESCRIPTION
Closes #2146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to manage stale issues and pull requests. Inactive items will be marked as stale after 180 days and closed after 5 additional days, with exemptions for backlog and bug-related items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ton-org/docs/pull/2160)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->