### PR TITLE
fix(api): update TON Center v2 repository references to the C++ implementation

### DIFF
--- a/ecosystem/api/overview.mdx
+++ b/ecosystem/api/overview.mdx
@@ -44,8 +44,8 @@ Access TON data via public liteservers, hosted APIs (TON Center v2/v3, TonAPI, d
 - [TON node and liteserver source](https://github.com/ton-blockchain/ton)
 - [Mainnet liteserver config][c], [testnet config][c-tn]
 - [TON Center landing page](https://toncenter.com)
-- [TON Center v2 (Python, older) source and deploy instructions][etc-v2-src]
-- [TON Center v2 (C++, newer) source and deploy instructions](https://github.com/toncenter/ton-http-api-cpp)
+- [TON Center v2 (Python, older) source and deploy instructions](https://github.com/toncenter/ton-http-api)
+- [TON Center v2 (C++, newer, recommended) source and deploy instructions][etc-v2-src]
 - [TON Center v3 source and deploy instructions][etc-v3-src]
 - [TonAPI site](https://tonapi.io), [REST docs][eta-doc], [Swagger][eta-swagger]
 - [OpenTonAPI (limited open-source)][eta-oss-src]
@@ -60,7 +60,7 @@ Access TON data via public liteservers, hosted APIs (TON Center v2/v3, TonAPI, d
 
 [etc-v2]: https://toncenter.com/api/v2
 [etc-v2-tn]: https://testnet.toncenter.com/api/v2
-[etc-v2-src]: https://github.com/toncenter/ton-http-api
+[etc-v2-src]: https://github.com/toncenter/ton-http-api-cpp
 [etc-v2-doc]: /ecosystem/api/toncenter/v2/overview
 [etc-v3]: https://toncenter.com/api/v3
 [etc-v3-tn]: https://testnet.toncenter.com/api/v3

--- a/ecosystem/api/overview.mdx
+++ b/ecosystem/api/overview.mdx
@@ -44,8 +44,8 @@ Access TON data via public liteservers, hosted APIs (TON Center v2/v3, TonAPI, d
 - [TON node and liteserver source](https://github.com/ton-blockchain/ton)
 - [Mainnet liteserver config][c], [testnet config][c-tn]
 - [TON Center landing page](https://toncenter.com)
-- [TON Center v2 (Python, older) source and deploy instructions](https://github.com/toncenter/ton-http-api)
 - [TON Center v2 (C++, newer, recommended) source and deploy instructions][etc-v2-src]
+- [TON Center v2 (Python, older) source and deploy instructions](https://github.com/toncenter/ton-http-api)
 - [TON Center v3 source and deploy instructions][etc-v3-src]
 - [TonAPI site](https://tonapi.io), [REST docs][eta-doc], [Swagger][eta-swagger]
 - [OpenTonAPI (limited open-source)][eta-oss-src]

--- a/ecosystem/api/toncenter/v2/overview.mdx
+++ b/ecosystem/api/toncenter/v2/overview.mdx
@@ -92,4 +92,4 @@ Requests without an API key are limited to a default rate of 1 request per secon
 
 ### Self-hosted service
 
-Run a self-hosted TON Center API v2 infrastructure for full control over performance and data retention. See the [API v2](https://github.com/toncenter/ton-http-api) repository for setup instructions.
+Run a self-hosted TON Center API v2 infrastructure for full control over performance and data retention. See the [API v2](https://github.com/toncenter/ton-http-api-cpp) repository for setup instructions.


### PR DESCRIPTION
closes [#2156](https://github.com/ton-org/docs/issues/2156)

Update all references for API/v2 in the documentation from the Python implementation to the C++ implementation.

From: https://github.com/toncenter/ton-http-api
To: https://github.com/toncenter/ton-http-api-cpp

UPD: keep the old link(for Python) as an alternative(for CPP) for a while. It will be deprecated later.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated TON Center API v2 documentation links to reference the C++ implementation repository for setup and deployment instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ton-org/docs/pull/2162)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->