### PR TITLE
chore: replace some redirects to old-docs.ton.org with existing pages

### DIFF
--- a/contribute/style-guide.mdx
+++ b/contribute/style-guide.mdx
@@ -3,6 +3,8 @@ title: "Documentation style guide"
 sidebarTitle: "Style guide"
 ---
 
+import { Aside } from '/snippets/aside.jsx';
+
 This guide covers the basics: how to structure pages, write examples, and keep docs consistent and safe.
 
 ## Write for the reader
@@ -72,17 +74,22 @@ Add a Caution or Warning when a step moves funds, changes fees or withdrawals, e
 
 On long guides with many risky commands, combine a clear page‑level warning at the top (covering risk, scope, rollback where feasible, and environment) with short local notes next to each critical step. Local notes can be brief if they point back to the main warning.
 
-Pattern
+Pattern:
 
-> Warning — funds at risk
-> Running the next command on mainnet transfers funds irreversibly.
-> Safer first (testnet):
+````
+<Aside
+  type="caution"
+  title="Funds at risk"
 >
-> ```bash
-> jetton transfer --to <ADDR> --amount <AMOUNT> --network testnet
-> ```
->
-> If you must use mainnet: no rollback; on‑chain transfers are final.
+  Running the next command on mainnet transfers funds irreversibly. Try on the testnet first:
+
+  ```bash
+  jetton transfer --to <ADDR> --amount <AMOUNT> --network testnet
+  ```
+
+  On-chain fund transfers on testnet and mainnet are irreversible.
+</Aside>
+````
 
 Default to testnet in task pages. Make destructive flags opt‑in and document mitigations.
 

--- a/docs.json
+++ b/docs.json
@@ -1304,7 +1304,7 @@
     },
     {
       "source": "/v3/documentation/dapps/assets/usdt",
-      "destination": "https://old-docs.ton.org/v3/documentation/dapps/assets/usdt",
+      "destination": "/standard/tokens/jettons/comparison#stablecoin-contract",
       "permanent": true
     },
     {
@@ -1324,7 +1324,7 @@
     },
     {
       "source": "/v3/documentation/dapps/defi/subscriptions",
-      "destination": "https://old-docs.ton.org/v3/documentation/dapps/defi/subscriptions",
+      "destination": "/standard/wallets/v4",
       "permanent": true
     },
     {
@@ -2069,7 +2069,7 @@
     },
     {
       "source": "/v3/guidelines/dapps/asset-processing/compressed-nfts",
-      "destination": "https://old-docs.ton.org/v3/guidelines/dapps/asset-processing/compressed-nfts",
+      "destination": "/standard/tokens/nft/comparison#cnft",
       "permanent": true
     },
     {
@@ -2139,7 +2139,7 @@
     },
     {
       "source": "/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools",
-      "destination": "https://old-docs.ton.org/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools",
+      "destination": "/ecosystem/staking/nominator-pools",
       "permanent": true
     },
     {
@@ -2404,12 +2404,12 @@
     },
     {
       "source": "/v3/contribute/README",
-      "destination": "https://old-docs.ton.org/v3/contribute/README",
+      "destination": "/contribute/style-guide",
       "permanent": true
     },
     {
       "source": "/v3/contribute",
-      "destination": "https://old-docs.ton.org/v3/contribute",
+      "destination": "/contribute/style-guide",
       "permanent": true
     },
     {
@@ -2419,22 +2419,22 @@
     },
     {
       "source": "/v3/contribute/content-standardization",
-      "destination": "https://old-docs.ton.org/v3/contribute/content-standardization",
+      "destination": "/contribute/style-guide",
       "permanent": true
     },
     {
       "source": "/v3/contribute/typography",
-      "destination": "https://old-docs.ton.org/v3/contribute/typography",
+      "destination": "/contribute/style-guide",
       "permanent": true
     },
     {
       "source": "/v3/contribute/localization-program/translation-style-guide",
-      "destination": "https://old-docs.ton.org/v3/contribute/localization-program/translation-style-guide",
+      "destination": "/contribute/style-guide",
       "permanent": true
     },
     {
       "source": "/v3/contribute/maintainers",
-      "destination": "https://old-docs.ton.org/v3/contribute/maintainers",
+      "destination": "/contribute/style-guide",
       "permanent": true
     },
     {
@@ -3089,7 +3089,7 @@
     },
     {
       "source": "/v3/contribute/participate",
-      "destination": "https://old-docs.ton.org/v3/contribute/participate",
+      "destination": "/contribute/style-guide",
       "permanent": true
     },
     {

--- a/standard/tokens/jettons/comparison.mdx
+++ b/standard/tokens/jettons/comparison.mdx
@@ -3,6 +3,8 @@ title: "Jetton implementations comparison"
 sidebarTitle: "Comparison"
 ---
 
+import { Aside } from '/snippets/aside.jsx';
+
 This article will compare different implementations of the TEP-74 standard and explore the best version for each use case.
 
 ## In short
@@ -35,7 +37,15 @@ For a long time, this version was the most widely adopted in the community. The 
 
 With the USDT release on TON, an advanced version of the Jetton contract was developed. This version introduces many new TVM gas assertion techniques, as well as extended functionality. Since USDT is a centralized asset, there are specific requirements and restrictions for its operations. More specifically, there is no _burn_ opcode, which means that formally, the Governance contract is not TEP-compliant, as Jetton burn functionality is part of the standard. Also, the Minter contract includes a _governance_ mechanism that allows users to perform any actions on other Jetton Wallets.
 
-Another noticeable advantage of this implementation is extensive testing. All previous versions didn't test edge cases of config changes that will affect storage / forward fees. This test suite became the foundation for all future Jetton versions.
+Another noticeable advantage of this implementation is extensive testing. All previous versions did not test edge cases of config changes that will affect storage or forward fees. This test suite became the foundation for all future Jetton versions.
+
+<Aside
+  type="caution"
+>
+  On TON, multiple jettons can share the same name — a counterfeit jetton may look identical to the real USDT but have no value. Verify legitimacy by confirming [USDT's jetton master address](https://tonviewer.com/EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs?section=jetton).
+
+  See important [recommendations when processing jettons](/payments/jettons#security-considerations).
+</Aside>
 
 ### Notcoin contract
 

--- a/standard/wallets/v4.mdx
+++ b/standard/wallets/v4.mdx
@@ -10,7 +10,7 @@ This version retains all the functionality of the previous versions and introduc
 
 Plugins enable developers to implement custom logic that integrates with wallet functionality. When a plugin is installed on a wallet through a signed transaction, it can force wallet to send internal message with predefined opcode (`0xf06c7567`) and any available Toncoin amount to specified addresses. Plugins are separate smart contracts that can implement their own custom logic.
 
-Here you can view [wallet V4 source code](https://github.com/ton-blockchain/wallet-contract).
+View the original [wallet V4 source code](https://github.com/ton-blockchain/wallet-contract) or the code of an [example subscription plugin](https://github.com/ton-blockchain/wallet-contract/blob/main/func/simple-subscription-plugin.fc).
 
 ## Plugins
 
@@ -23,7 +23,7 @@ Here you can view [wallet V4 source code](https://github.com/ton-blockchain/wall
 <Aside
   type="caution"
 >
-  Due to security reasons mentioned above, it is not possible to install plugins using [TonConnect](/ecosystem/ton-connect/overview).
+  Due to security reasons mentioned above, it is not possible to install plugins using [TON Connect](/ecosystem/ton-connect/overview).
 </Aside>
 
 Plugins are essentially other smart contracts on TON that developers are free to implement as they wish. In relation to the wallet, they are simply addresses of smart contracts stored in a dictionary in the wallet's persistent memory. These plugins are allowed to request funds and remove themselves from the "allowed list" by sending internal messages to the wallet.


### PR DESCRIPTION
Closes #2177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved security warning formatting in the style guide using enhanced callout components.
  * Updated legacy documentation redirects to new in-site routes.
  * Enhanced jetton security guidance with recommendations for name verification.
  * Updated wallet implementation reference links and documentation links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ton-org/docs/pull/2178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->