### PR TITLE
chore(docs.json): expand wildcard `:slug*` redirects

### DIFF
--- a/.github/workflows/bouncer.yml
+++ b/.github/workflows/bouncer.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   enforce-better-titles:
-    name: "Conventional Commits titles"
+    name: "Conventional Commits-adhering title"
     runs-on: ubuntu-latest
     steps:
       # pr title check

--- a/docs.json
+++ b/docs.json
@@ -1435,6 +1435,11 @@
       "permanent": true
     },
     {
+      "source": "/learn/introduction",
+      "destination": "/start-here",
+      "permanent": true
+    },
+    {
       "source": "/learn/overviews/ton-blockchain",
       "destination": "/start-here",
       "permanent": true
@@ -3125,6 +3130,11 @@
       "permanent": true
     },
     {
+      "source": "/develop/smart-contracts/testing/toncli",
+      "destination": "/contract-dev/acton",
+      "permanent": true
+    },
+    {
       "source": "/develop/smart-contracts/guidelines",
       "destination": "/v3/guidelines/smart-contracts/guidelines",
       "permanent": true
@@ -3446,6 +3456,11 @@
     },
     {
       "source": "/participate/run-nodes/full-node",
+      "destination": "/v3/guidelines/nodes/running-nodes/full-node",
+      "permanent": true
+    },
+    {
+      "source": "/participate/nodes/run-node",
       "destination": "/v3/guidelines/nodes/running-nodes/full-node",
       "permanent": true
     },

--- a/docs.json
+++ b/docs.json
@@ -3550,18 +3550,228 @@
       "permanent": true
     },
     {
-      "source": "/ecosystem/node/mytonctrl/:slug*",
-      "destination": "/ecosystem/nodes/cpp/mytonctrl/:slug*",
+      "source": "/ecosystem/node/mytonctrl/alerting",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/alerting",
       "permanent": true
     },
     {
-      "source": "/ecosystem/ton-connect/appkit/:slug*",
-      "destination": "/ecosystem/appkit/:slug*",
+      "source": "/ecosystem/node/mytonctrl/backups",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/backups",
       "permanent": true
     },
     {
-      "source": "/ecosystem/ton-connect/walletkit/:slug*",
-      "destination": "/ecosystem/walletkit/:slug*",
+      "source": "/ecosystem/node/mytonctrl/btc-teleport",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/btc-teleport",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/node/mytonctrl/collator",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/collator",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/node/mytonctrl/core",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/core",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/node/mytonctrl/custom-overlays",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/custom-overlays",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/node/mytonctrl/installer",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/installer",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/node/mytonctrl/liquid-staking",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/liquid-staking",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/node/mytonctrl/overview",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/overview",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/node/mytonctrl/pools",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/pools",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/node/mytonctrl/utilities",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/utilities",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/node/mytonctrl/validator",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/validator",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/node/mytonctrl/wallet",
+      "destination": "/ecosystem/nodes/cpp/mytonctrl/wallet",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/appkit/init",
+      "destination": "/ecosystem/appkit/init",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/appkit/jettons",
+      "destination": "/ecosystem/appkit/jettons",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/appkit/nfts",
+      "destination": "/ecosystem/appkit/nfts",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/appkit/overview",
+      "destination": "/ecosystem/appkit/overview",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/appkit/stake",
+      "destination": "/ecosystem/appkit/stake",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/appkit/swap",
+      "destination": "/ecosystem/appkit/swap",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/appkit/toncoin",
+      "destination": "/ecosystem/appkit/toncoin",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/ios/wallets",
+      "destination": "/ecosystem/walletkit/ios/wallets",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/ios/init",
+      "destination": "/ecosystem/walletkit/ios/init",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/ios/webview",
+      "destination": "/ecosystem/walletkit/ios/webview",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/ios/data",
+      "destination": "/ecosystem/walletkit/ios/data",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/ios/events",
+      "destination": "/ecosystem/walletkit/ios/events",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/ios/installation",
+      "destination": "/ecosystem/walletkit/ios/installation",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/ios/transactions",
+      "destination": "/ecosystem/walletkit/ios/transactions",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/android/wallets",
+      "destination": "/ecosystem/walletkit/android/wallets",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/android/init",
+      "destination": "/ecosystem/walletkit/android/init",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/android/webview",
+      "destination": "/ecosystem/walletkit/android/webview",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/android/data",
+      "destination": "/ecosystem/walletkit/android/data",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/android/events",
+      "destination": "/ecosystem/walletkit/android/events",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/android/installation",
+      "destination": "/ecosystem/walletkit/android/installation",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/android/transactions",
+      "destination": "/ecosystem/walletkit/android/transactions",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/web/connections",
+      "destination": "/ecosystem/walletkit/web/connections",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/web/wallets",
+      "destination": "/ecosystem/walletkit/web/wallets",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/web/init",
+      "destination": "/ecosystem/walletkit/web/init",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/web/nfts",
+      "destination": "/ecosystem/walletkit/web/nfts",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/web/jettons",
+      "destination": "/ecosystem/walletkit/web/jettons",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/web/toncoin",
+      "destination": "/ecosystem/walletkit/web/toncoin",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/web/events",
+      "destination": "/ecosystem/walletkit/web/events",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/overview",
+      "destination": "/ecosystem/walletkit/overview",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/browser-extension",
+      "destination": "/ecosystem/walletkit/browser-extension",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/native-web",
+      "destination": "/ecosystem/walletkit/native-web",
+      "permanent": true
+    },
+    {
+      "source": "/ecosystem/ton-connect/walletkit/qa-guide",
+      "destination": "/ecosystem/walletkit/qa-guide",
       "permanent": true
     },
     {
@@ -3585,8 +3795,248 @@
       "permanent": true
     },
     {
-      "source": "/languages/tolk/:slug*",
-      "destination": "/tolk/:slug*",
+      "source": "/languages/tolk/syntax/exceptions",
+      "destination": "/tolk/syntax/exceptions",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/syntax/structures-fields",
+      "destination": "/tolk/syntax/structures-fields",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/syntax/operators",
+      "destination": "/tolk/syntax/operators",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/syntax/variables",
+      "destination": "/tolk/syntax/variables",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/syntax/imports",
+      "destination": "/tolk/syntax/imports",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/syntax/mutability",
+      "destination": "/tolk/syntax/mutability",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/syntax/functions-methods",
+      "destination": "/tolk/syntax/functions-methods",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/syntax/pattern-matching",
+      "destination": "/tolk/syntax/pattern-matching",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/syntax/conditions-loops",
+      "destination": "/tolk/syntax/conditions-loops",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/overview",
+      "destination": "/tolk/overview",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/basic-syntax",
+      "destination": "/tolk/basic-syntax",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/changelog",
+      "destination": "/tolk/changelog",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/from-func/tolk-vs-func",
+      "destination": "/tolk/from-func/tolk-vs-func",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/from-func/stdlib-comparison",
+      "destination": "/tolk/from-func/stdlib-comparison",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/from-func/converter",
+      "destination": "/tolk/from-func/converter",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/idioms-conventions",
+      "destination": "/tolk/idioms-conventions",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/examples",
+      "destination": "/tolk/examples",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/strings",
+      "destination": "/tolk/types/strings",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/numbers",
+      "destination": "/tolk/types/numbers",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/void-never",
+      "destination": "/tolk/types/void-never",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/cells",
+      "destination": "/tolk/types/cells",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/aliases",
+      "destination": "/tolk/types/aliases",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/overall-tvm-stack",
+      "destination": "/tolk/types/overall-tvm-stack",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/unknown",
+      "destination": "/tolk/types/unknown",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/tuples",
+      "destination": "/tolk/types/tuples",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/maps",
+      "destination": "/tolk/types/maps",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/nullable",
+      "destination": "/tolk/types/nullable",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/generics",
+      "destination": "/tolk/types/generics",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/structures",
+      "destination": "/tolk/types/structures",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/address",
+      "destination": "/tolk/types/address",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/booleans",
+      "destination": "/tolk/types/booleans",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/unions",
+      "destination": "/tolk/types/unions",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/overall-serialization",
+      "destination": "/tolk/types/overall-serialization",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/type-checks-and-casts",
+      "destination": "/tolk/types/type-checks-and-casts",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/tensors",
+      "destination": "/tolk/types/tensors",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/list-of-types",
+      "destination": "/tolk/types/list-of-types",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/callables",
+      "destination": "/tolk/types/callables",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/types/enums",
+      "destination": "/tolk/types/enums",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/contract-storage",
+      "destination": "/tolk/features/contract-storage",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/standard-library",
+      "destination": "/tolk/features/standard-library",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/contract-abi",
+      "destination": "/tolk/features/contract-abi",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/message-sending",
+      "destination": "/tolk/features/message-sending",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/message-handling",
+      "destination": "/tolk/features/message-handling",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/jetton-payload",
+      "destination": "/tolk/features/jetton-payload",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/compiler-optimizations",
+      "destination": "/tolk/features/compiler-optimizations",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/contract-getters",
+      "destination": "/tolk/features/contract-getters",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/auto-serialization",
+      "destination": "/tolk/features/auto-serialization",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/asm-functions",
+      "destination": "/tolk/features/asm-functions",
+      "permanent": true
+    },
+    {
+      "source": "/languages/tolk/features/lazy-loading",
+      "destination": "/tolk/features/lazy-loading",
       "permanent": true
     },
     {


### PR DESCRIPTION
This was important to do for manual redirect file generation in case we'll have a fully static build and to ensure that no links are lost.

Also added redirects for URLs discovered by @Danil42Russia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refined documentation redirects for ecosystem resources (MyTonCtrl, TON Connect components) and Tolk language documentation to ensure consistent link accessibility and improve user navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ton-org/docs/pull/2180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->