### PR TITLE
chore: add Phalanx Toolkit to no-code Jetton deployers list

### DIFF
--- a/content/more-tutorials.mdx
+++ b/content/more-tutorials.mdx
@@ -85,6 +85,12 @@ Examples of smart contracts on TON include wallets, electors (which manage valid
 
 - [Tolk benchmark contracts](https://github.com/ton-blockchain/tolk-bench) - Tolk vs. FunC gas benchmarks and, simultaneously, reference Tolk contracts.
 
+## No-code Jetton deployers
+
+Community tools that deploy standard Jettons without writing custom contract code:
+
+- [Phalanx Toolkit](https://plx.foundation) — audited Jetton deploy wizard on TON/GRAM (Acton + Tolk contracts, Tonkeeper + TON Connect). Step-by-step guide: [How to create your own crypto token without code](https://plx.foundation/guides/create-token). Open-source contracts: [phalanx-foundation/plx-token](https://github.com/phalanx-foundation/plx-token).
+
 ## Join the community
 
 - [All TON communities](https://ton.org/en/community)


### PR DESCRIPTION
Adds Phalanx Toolkit — community no-code Jetton deployer with audited open-source contracts (phalanx-foundation/plx-token).

Guide: https://plx.foundation/guides/create-token

Curated entry under **No-code Jetton deployers** on more-tutorials.mdx.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "No-code Jetton deployers" subsection to Smart contract examples resources, featuring the Phalanx Toolkit with links to its deployment guide and open-source contract implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->