### PR TITLE
fix: center images by default, re-enable image zoom, and some other minor fixes

### DIFF
--- a/.github/workflows/deployer.yml
+++ b/.github/workflows/deployer.yml
@@ -59,7 +59,7 @@ jobs:
           GITHUB_PAGES: ${{ github.event_name != 'pull_request' && 'true' || '' }}
         run: |
           npm run build
-          if [ '${{ env.GITHUB_PAGES }}' ]; then
+          if [ -z '${{ env.GITHUB_PAGES }}' ]; then
             nlines=20
             target='llms.txt'
             test -f "$target" && echo -e "\nFirst $nlines lines of $target" && head -$nlines "out/$target"

--- a/.github/workflows/deployer.yml
+++ b/.github/workflows/deployer.yml
@@ -57,7 +57,19 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: '1'
           GITHUB_PAGES: ${{ github.event_name != 'pull_request' && 'true' || '' }}
-        run: npm run build
+        run: |
+          npm run build
+          if [ '${{ env.GITHUB_PAGES }}' ]; then
+            nlines=20
+            target='llms.txt'
+            test -f "$target" && echo -e "\nFirst $nlines lines of $target" && head -$nlines "out/$target"
+            target='llms-full.txt'
+            test -f "$target" && echo -e "\nFirst $nlines lines of $target" && head -$nlines "out/$target"
+            target='llms/foundations/tlb/overview/content.md'
+            test -f "$target" && echo -e "\nFirst $nlines lines of $target" && head -$nlines "out/$target"
+            target='404.html'
+            test -f "$target" && echo -e "\nFirst $nlines lines of $target" && head -$nlines "out/$target"
+          fi
 
       - name: Save NPM cache
         id: npm-cache-save

--- a/content/get-support.mdx
+++ b/content/get-support.mdx
@@ -2,7 +2,7 @@
 title: "Get support"
 ---
 
-Use <kbd>Ctrl + K</kbd> to do an indexed search. Supply the [`llms.txt` file](/llms.txt) to an AI agent for accurate context.
+Use <kbd>Ctrl + K</kbd> to do an indexed search. Supply the [`llms.txt` file](llms.txt) to an AI agent for accurate context.
 
 {/* TODO(restore when available, suggest AI skills): with AI fallback, or press <kbd>Ctrl + I</kbd> to open the assistant panel directly. */}
 

--- a/next.config.static.ts
+++ b/next.config.static.ts
@@ -49,7 +49,6 @@ const config: NextConfig = {
     ? {
         experimental: {
           cpus: 4,
-          workerThreads: false,
         },
       }
     : {}),

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "next dev",
     "start": "next dev",
     "start:vercel": "NEXT_CONFIG=vercel next start",
-    "build": "node scripts/pre-build.mjs && cross-env NODE_OPTIONS=--max_old_space_size=2048 next build && node scripts/post-build.mjs",
+    "build": "node scripts/pre-build.mjs && cross-env NODE_OPTIONS=--max_old_space_size=4096 next build && node scripts/post-build.mjs",
     "build:vercel": "node scripts/pre-build.mjs && NEXT_CONFIG=vercel next build",
     "build:serve": "serve out",
     "check:types": "fumadocs-mdx && next typegen && tsc --noEmit",

--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -35,13 +35,13 @@ const rewrite = (path) => {
 /** @param {string} text */
 const prefixUrls = (text) => {
   const attrPattern =
-    /\b(src|href|poster|darkSrc)=(["'])(\/(?:images|logo|pdfs|tvm|videos)\/(?!\/)[^"']*)\2/g;
+    /\b(src|href|poster|darkSrc)=(["'])(\/(?:images|logo|pdfs|videos)\/(?!\/)[^"']*)\2/g;
   const doubleQuoteAttrPattern =
-    /\b(src|href|poster|darkSrc)":"(\/(?:images|logo|pdfs|tvm|videos)\/(?!\/)[^"]*)"/g;
-  const cssUrlPattern = /url\((["']?)(\/(?:images|logo|pdfs|tvm|videos)\/(?!\/)[^)"']*)\1\)/g;
+    /\b(src|href|poster|darkSrc)":"(\/(?:images|logo|pdfs|videos)\/(?!\/)[^"]*)"/g;
+  const cssUrlPattern = /url\((["']?)(\/(?:images|logo|pdfs|videos)\/(?!\/)[^)"']*)\1\)/g;
   // NOTE: only for api/search?
   const specAttrPattern =
-    /\b(src|href|poster|darkSrc)(\\["']):\2(\/(?:images|logo|pdfs|tvm|videos)\/(?!\/)[^\\"']*)\2/g;
+    /\b(src|href|poster|darkSrc)(\\["']):\2(\/(?:images|logo|pdfs|videos)\/(?!\/)[^\\"']*)\2/g;
   let replacements = 0;
   const next = text
     .replace(attrPattern, (match, attr, quote, path) => {

--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -75,8 +75,8 @@ const prefixUrls = (text) => {
 const prefixAssetLinks = (dir) => {
   /** @type {{ files: number; replacements: number }} */
   const stats = { files: 0, replacements: 0 };
-  // NOTE: only edit html, never .txt, .js, .css, .md?
-  const exts = new Set(['.html']);
+  // NOTE: never edit .css?
+  const exts = new Set(['.html', '.txt', '.js', '.md']);
 
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const path = join(dir, entry.name);
@@ -151,10 +151,11 @@ const main = (dir) => {
     process.exit(1);
   }
 
-  console.log(pfx, `prefixing links...`);
-  const { files, replacements } = prefixAssetLinks(dir);
-  console.log(pfx, `${files} files, ${replacements} replacements`);
-  console.log();
+  // NOTE: consider removing in favor of a remark plugin pre- or post-processing
+  // console.log(pfx, `prefixing links...`);
+  // const { files, replacements } = prefixAssetLinks(dir);
+  // console.log(pfx, `${files} files, ${replacements} replacements`);
+  // console.log();
   console.log(pfx, `generating static http-refresh redirects...`);
   const { redirects } = generateStaticRedirects(dir);
   console.log(pfx, `${redirects} redirects`);

--- a/snippets/stub-components.jsx
+++ b/snippets/stub-components.jsx
@@ -1,8 +1,7 @@
-/**
- * Shim components for the Mintlify -> Fumadocs migration.
- */
+import Link from 'fumadocs-core/link';
 
 /**
+ * Shim component for the Mintlify -> Fumadocs migration.
  * TODO: keep it as is or take from OpenAPI
  *
  * @param {{
@@ -26,6 +25,7 @@ export const ParamField = ({ path = '', body = '', type = '', required = false, 
 );
 
 /**
+ * Shim component for the Mintlify -> Fumadocs migration.
  * TODO: keep it as is or take from OpenAPI
  *
  * @param {{
@@ -48,6 +48,7 @@ export const ResponseField = ({ name = '', type = '', required = false, children
 );
 
 /**
+ * Shim component for the Mintlify -> Fumadocs migration.
  * TODO: Lightweight shim, enhance further.
  *
  * @param {{
@@ -63,7 +64,7 @@ export const Tooltip = ({ tip = '', cta = '', href = '', children }) => (
     {cta && href && (
       <>
         {' '}
-        <a href={href}>{cta}</a>
+        <Link href={href}>{cta}</Link>
       </>
     )}
   </span>

--- a/snippets/tvm-instruction-table.jsx
+++ b/snippets/tvm-instruction-table.jsx
@@ -22,7 +22,7 @@ export const TvmInstructionTable = () => {
 
   const PERSIST_KEY = 'tvm-instruction-table::filters';
 
-  const SPEC_URL = 'tvm/cp0.txt';
+  const SPEC_URL = 'cp0.txt';
 
   const CATEGORY_MAP = {
     stack_basic: 'Stack basics',

--- a/src/app/(docs)/[...slug]/page.tsx
+++ b/src/app/(docs)/[...slug]/page.tsx
@@ -98,6 +98,7 @@ export async function generateMetadata(props: PageProps<'/[...slug]'>): Promise<
   return {
     title: page.data.title,
     description: page.data.description,
+    metadataBase: process.env.NEXT_PUBLIC_BASE_URL,
     alternates: {
       ...(page.data.url ? {} : { canonical: page.url }),
       types: {

--- a/src/app/(docs)/[...slug]/page.tsx
+++ b/src/app/(docs)/[...slug]/page.tsx
@@ -56,7 +56,7 @@ export default async function Page(props: PageProps<'/[...slug]'>) {
     >
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription className="mb-0">{page.data.description}</DocsDescription>
-      {page.data._openapi ? (
+      {page.data._openapi || page.slugs.includes('whitepapers') ? (
         <></>
       ) : (
         <div className="flex flex-row flex-wrap gap-2 items-center border-b pb-6">

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: 'TON documentation',
   description:
     'TON is a blockchain platform designed for scalable smart contracts, applications, and payments at consumer scale.',
+  metadataBase: process.env.NEXT_PUBLIC_BASE_URL,
   openGraph: {
     images: 'logo/og-image.png',
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,12 +15,12 @@ export const metadata: Metadata = {
   icons: {
     icon: [
       {
-        url: logoLight,
+        url: logoLight.src,
         media: '(prefers-color-scheme: light)',
         type: 'image/svg+xml',
       },
       {
-        url: logoDark,
+        url: logoDark.src,
         media: '(prefers-color-scheme: dark)',
         type: 'image/svg+xml',
       },

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,8 +1,12 @@
-import { source } from '@/lib/source';
+import { source, processLLMLinks } from '@/lib/source';
 import { llms } from 'fumadocs-core/source';
 
 export const revalidate = false;
 
 export function GET() {
-  return new Response(llms(source).index());
+  return new Response(processLLMLinks(llms(source).index()), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
 }

--- a/src/app/llms/[[...slug]]/route.ts
+++ b/src/app/llms/[[...slug]]/route.ts
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 
 export const revalidate = false;
 
-export async function GET(_req: Request, { params }: RouteContext<'/llms.mdx/[[...slug]]'>) {
+export async function GET(_req: Request, { params }: RouteContext<'/llms/[[...slug]]'>) {
   const { slug } = await params;
   // remove the appended "content.md"
   const page = source.getPage(slug?.slice(0, -1));
@@ -11,7 +11,7 @@ export async function GET(_req: Request, { params }: RouteContext<'/llms.mdx/[[.
 
   return new Response(await getLLMText(page), {
     headers: {
-      'Content-Type': 'text/markdown',
+      'Content-Type': 'text/markdown; charset=utf-8',
     },
   });
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -24,24 +24,22 @@ export default function NotFound() {
       <div className="flex flex-col items-center justify-center text-center gap-4 p-8 [grid-area:main]">
         <p className="text-sm font-medium text-fd-muted-foreground">404</p>
         <h1 className="mt-2 text-3xl font-bold tracking-tight sm:text-4xl">Page not found</h1>
-        <div className="mt-4 w-full">
-          <p className="max-w-md text-fd-muted-foreground">
-            The page you are looking for does not exist :(
-          </p>
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-            <Link
-              href="/"
-              className="rounded-md bg-fd-primary px-4 py-2 text-sm font-medium text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
-            >
-              Go to the home page
-            </Link>
-            <Link
-              href="/get-support"
-              className="rounded-md border border-fd-border px-4 py-2 text-sm font-medium transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
-            >
-              Ask in chats
-            </Link>
-          </div>
+        <p className="max-w-md text-fd-muted-foreground">
+          The page you are looking for does not exist :(
+        </p>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+          <Link
+            href="/"
+            className="rounded-md bg-fd-primary px-4 py-2 text-sm font-medium text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
+          >
+            Home page
+          </Link>
+          <Link
+            href="/get-support"
+            className="rounded-md border border-fd-border px-4 py-2 text-sm font-medium transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+          >
+            Get support
+          </Link>
         </div>
       </div>
     </DocsLayout>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -13,11 +13,17 @@ export default function NotFound() {
       sidebar={{
         collapsible: false,
       }}
+      tabMode="top"
+      // NOTE: Must mirror (docs)/layout.tsx
       containerProps={{
         style: {
-          gridTemplate: `"sidebar . header toc toc"
-"sidebar . toc-popover toc toc"
-"sidebar . main toc toc" 1fr / var(--fd-sidebar-col) minmax(min-content, 1fr) minmax(0, calc(var(--fd-layout-width,97rem) - var(--fd-sidebar-width) - var(--fd-toc-width))) var(--fd-toc-width) minmax(min-content, 1fr)`,
+          gridTemplate: [
+            `"sidebar . header toc toc"`,
+            `"sidebar . tabs toc toc"`,
+            `"sidebar . toc-popover toc toc"`,
+            `"sidebar . main toc toc"`,
+            `1fr / var(--fd-sidebar-col) minmax(min-content, 1fr) minmax(0, calc(var(--fd-layout-width,97rem) - var(--fd-sidebar-width) - var(--fd-toc-width))) var(--fd-toc-width) minmax(min-content, 1fr)`,
+          ].join(' '),
         },
       }}
     >

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -22,6 +22,9 @@ import { ParamField, ResponseField, Tooltip } from '@/snippets/stub-components';
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    // See: https://www.fumadocs.dev/docs/ui/components/image-zoom
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    img: (props) => <ImageZoom {...(props as any)} />,
     // See: https://www.fumadocs.dev/docs/integrations/openapi/api-page
     APIPage,
     // See: https://www.fumadocs.dev/docs/markdown/mermaid
@@ -54,9 +57,6 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     FileTree,
     Icon,
     Badge,
-    // See: https://www.fumadocs.dev/docs/ui/components/image-zoom
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    img: (props) => <ImageZoom {...(props as any)} />,
     // Page-specific components
     CatchainVisualizer,
     TvmInstructionTable,

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -2,6 +2,7 @@ import type { MDXComponents } from 'mdx/types';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import { APIPage } from '@/components/api-page';
 import { ImageZoom } from '@/components/mdx/image-zoom';
+import { Video } from '@/components/mdx/video';
 import { Mermaid } from '@/components/mdx/mermaid';
 import { File, Files, Folder } from '@/components/mdx/files';
 import { Accordion, Accordions } from '@/components/mdx/accordion';
@@ -25,6 +26,9 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     // See: https://www.fumadocs.dev/docs/ui/components/image-zoom
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     img: (props) => <ImageZoom {...(props as any)} />,
+    // Prefixes `src` and `poster` props with base path
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    video: (props) => <Video {...(props as any)} />,
     // See: https://www.fumadocs.dev/docs/integrations/openapi/api-page
     APIPage,
     // See: https://www.fumadocs.dev/docs/markdown/mermaid

--- a/src/components/mdx/callout.tsx
+++ b/src/components/mdx/callout.tsx
@@ -53,8 +53,6 @@ export function CalloutContainer({
   ...props
 }: CalloutContainerProps) {
   const type = resolveAlias(inputType);
-  const colorSuffix = (inputType as unknown) === 'danger' ? 'error' : type;
-
   return (
     <div
       className={cn(
@@ -63,7 +61,13 @@ export function CalloutContainer({
       )}
       style={
         {
-          '--callout-color': `var(--color-fd-${colorSuffix}, var(--color-fd-muted))`,
+          '--callout-color': {
+            info: 'var(--color-fd-info, var(--color-fd-primary))',
+            warning: 'var(--color-fd-warning, var(--color-fd-primary))',
+            error: 'var(--color-fd-error, var(--color-fd-primary))',
+            success: 'var(--color-fd-success, var(--color-fd-primary))',
+            idea: 'var(--color-fd-idea, var(--color-fd-primary))',
+          }[(inputType as unknown) === 'danger' ? 'error' : type],
           ...style,
         } as object
       }
@@ -71,13 +75,11 @@ export function CalloutContainer({
     >
       {icon ??
         {
-          info: <Info className={iconClass} />,
-          warning: <TriangleAlert className={iconClass} />,
-          error: <CircleX className={iconClass} />,
-          success: <CircleCheck className={iconClass} />,
-          idea: (
-            <Lightbulb className="size-5 -me-0.5 fill-(--callout-color) text-(--callout-color)" />
-          ),
+          info: <Info className={cn(iconClass, 'text-fd-card')} />,
+          warning: <TriangleAlert className={cn(iconClass, 'text-fd-card')} />,
+          error: <CircleX className={cn(iconClass, 'text-fd-card')} />,
+          success: <CircleCheck className={cn(iconClass, 'text-fd-card')} />,
+          idea: <Lightbulb className={cn(iconClass, 'text-(--callout-color)')} />,
         }[type]}
       <div className="flex flex-col gap-2 min-w-0 flex-1">{children}</div>
     </div>

--- a/src/components/mdx/card.tsx
+++ b/src/components/mdx/card.tsx
@@ -31,7 +31,7 @@ export type ColumnsProps = HTMLAttributes<HTMLDivElement> & {
 /** Responsive grid of cards */
 export function Columns({ cols = 2, className, children, ...props }: ColumnsProps) {
   return (
-    <div {...props} className={cn('grid gap-3 @container', COLS[cols] ?? COLS[2], className)}>
+    <div {...props} className={cn('grid gap-x-3 gap-y-1 @container', COLS[cols] ?? COLS[2], className)}>
       {children}
     </div>
   );
@@ -105,7 +105,7 @@ export function Card({
       {img ? (
         <img src={img} alt="" className="not-prose w-full object-cover object-center" />
       ) : null}
-      <div className={cn('relative p-4', horizontal && 'flex items-start gap-4')}>
+      <div className={cn('relative p-4', horizontal && 'flex items-center gap-4')}>
         {showArrow ? (
           <div
             aria-hidden

--- a/src/components/mdx/card.tsx
+++ b/src/components/mdx/card.tsx
@@ -31,7 +31,10 @@ export type ColumnsProps = HTMLAttributes<HTMLDivElement> & {
 /** Responsive grid of cards */
 export function Columns({ cols = 2, className, children, ...props }: ColumnsProps) {
   return (
-    <div {...props} className={cn('grid gap-x-3 gap-y-1 @container', COLS[cols] ?? COLS[2], className)}>
+    <div
+      {...props}
+      className={cn('grid gap-x-3 gap-y-1 @container', COLS[cols] ?? COLS[2], className)}
+    >
       {children}
     </div>
   );

--- a/src/components/mdx/icon.tsx
+++ b/src/components/mdx/icon.tsx
@@ -40,7 +40,7 @@ const ICON_ALIASES: Record<string, string> = {
   'file-pdf': 'FileText',
   'list-ol': 'ListOrdered',
   message: 'MessageSquare',
-  'input-text': 'FormInput',
+  'input-text': 'TextCursorInput',
   'arrow-left-arrow-right': 'ArrowLeftRight',
   'chart-diagram': 'Workflow',
   'building-columns': 'Landmark',

--- a/src/components/mdx/icon.tsx
+++ b/src/components/mdx/icon.tsx
@@ -37,6 +37,7 @@ const ICON_ALIASES: Record<string, string> = {
   'signal-stream': 'RadioTower',
   'user-group': 'Users',
   'chart-line': 'ChartLine',
+  'file-pdf': 'FileText',
 };
 
 /**

--- a/src/components/mdx/icon.tsx
+++ b/src/components/mdx/icon.tsx
@@ -38,6 +38,23 @@ const ICON_ALIASES: Record<string, string> = {
   'user-group': 'Users',
   'chart-line': 'ChartLine',
   'file-pdf': 'FileText',
+  'list-ol': 'ListOrdered',
+  message: 'MessageSquare',
+  'input-text': 'FormInput',
+  'arrow-left-arrow-right': 'ArrowLeftRight',
+  'chart-diagram': 'Workflow',
+  'building-columns': 'Landmark',
+  'layer-group': 'Layers',
+  'table-cells': 'Grid3x3',
+  'floppy-disk': 'Save',
+  'file-js': 'FileCode',
+  // Brand icons that Lucide does not ship are mapped to the closest generic glyph:
+  react: 'Atom',
+  github: 'GitBranch',
+  npm: 'Package',
+  js: 'Braces',
+  telegram: 'Send',
+  'square-n': 'SquareCode',
 };
 
 /**

--- a/src/components/mdx/image-zoom.tsx
+++ b/src/components/mdx/image-zoom.tsx
@@ -4,6 +4,7 @@ import { Image, type ImageProps } from 'fumadocs-core/framework';
 import type { ComponentProps } from 'react';
 import Zoom, { type UncontrolledProps } from 'react-medium-image-zoom';
 import '../../styles/image-zoom.css';
+import { withBasePath } from '@/lib/shared';
 
 export type ImageZoomProps = ImageProps & {
   /**
@@ -19,30 +20,29 @@ export type ImageZoomProps = ImageProps & {
 
 function getImageSrc(src: ImageProps['src']): string {
   if (typeof src === 'string') return src;
-
   if (typeof src === 'object') {
     // Next.js
     if ('default' in src) return (src as { default: { src: string } }).default.src;
     return src.src;
   }
-
   return '';
 }
 
 export function ImageZoom({ zoomInProps, children, rmiz, ...props }: ImageZoomProps) {
+  const src = typeof props.src === 'string' ? withBasePath(props.src) : props.src;
   return (
     <Zoom
       zoomMargin={20}
       wrapElement="span"
       {...rmiz}
       zoomImg={{
-        src: getImageSrc(props.src),
+        src: getImageSrc(src),
         sizes: undefined,
         ...zoomInProps,
       }}
     >
       {children ?? (
-        <Image sizes="(max-width: 768px) 100vw, (max-width: 1200px) 70vw, 900px" {...props} />
+        <Image sizes="(max-width: 768px) 100vw, (max-width: 1200px) 70vw, 900px" {...props} src={src} />
       )}
     </Zoom>
   );

--- a/src/components/mdx/image-zoom.tsx
+++ b/src/components/mdx/image-zoom.tsx
@@ -42,7 +42,11 @@ export function ImageZoom({ zoomInProps, children, rmiz, ...props }: ImageZoomPr
       }}
     >
       {children ?? (
-        <Image sizes="(max-width: 768px) 100vw, (max-width: 1200px) 70vw, 900px" {...props} src={src} />
+        <Image
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 70vw, 900px"
+          {...props}
+          src={src}
+        />
       )}
     </Zoom>
   );

--- a/src/components/mdx/image.jsx
+++ b/src/components/mdx/image.jsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'fumadocs-core/link';
 import { ImageZoom } from './image-zoom';
 import { Callout } from './callout';
 
@@ -131,17 +132,17 @@ export const Image = ({
     if (shouldCenter) {
       return (
         <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <a href={href} target={target ?? '_self'}>
+          <Link href={href} target={target ?? '_self'}>
             {images}
-          </a>
+          </Link>
         </div>
       );
     }
 
     return (
-      <a href={href} target={target ?? '_self'}>
+      <Link href={href} target={target ?? '_self'}>
         {images}
-      </a>
+      </Link>
     );
   }
 

--- a/src/components/mdx/image.jsx
+++ b/src/components/mdx/image.jsx
@@ -1,4 +1,6 @@
 'use client';
+
+import { ImageZoom } from './image-zoom';
 import { Callout } from './callout';
 
 /**
@@ -25,7 +27,7 @@ export const Image = ({
   height = 342,
   width = 608,
   noZoom = false,
-  center = false,
+  center = true,
 }) => {
   const isSVG = src.match(/\.svg(?:[#?].*?)?$/i) !== null;
   const shouldInvert = isSVG && !darkSrc;
@@ -98,7 +100,7 @@ export const Image = ({
   // Resulting images
   const images = (
     <>
-      <img
+      <ImageZoom
         className="block dark:hidden"
         src={src}
         alt={alt}
@@ -106,10 +108,10 @@ export const Image = ({
         {...(width && { width: widthPx })}
         // @ts-ignore
         {...((shouldCreateLink || shouldInvert || shouldNotZoom) && {
-          noZoom: 'true',
+          isDisabled: true,
         })}
       />
-      <img
+      <ImageZoom
         className={`hidden dark:block ${shouldInvert ? 'invert' : ''}`}
         src={darkSrc ?? src}
         alt={darkAlt ?? alt}
@@ -117,7 +119,7 @@ export const Image = ({
         {...(width && { width: widthPx })}
         // @ts-ignore
         {...((shouldCreateLink || shouldInvert || shouldNotZoom) && {
-          noZoom: 'true',
+          isDisabled: true,
         })}
       />
     </>

--- a/src/components/mdx/video.tsx
+++ b/src/components/mdx/video.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import { withBasePath } from '@/lib/shared';
+
+export function Video({ src, poster, children, ...props }: ComponentProps<'video'>) {
+  return (
+    <video
+      {...props}
+      {...(typeof src === 'string' ? { src: withBasePath(src) } : {})}
+      {...(typeof poster === 'string' ? { poster: withBasePath(poster) } : {})}
+    >
+      {children}
+    </video>
+  );
+}

--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -1,11 +1,12 @@
 // Constants
 const pathPrefix = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const urlPrefix = (process.env.NEXT_PUBLIC_BASE_URL ?? '').replace(/\/+$/, '');
 export const appName = 'TON Docs';
 // Next.js automatically prepends `basePath` to sidebar and page <Link> hrefs.
 // Do not include the prefix here lest you want to double it (e.g. /docs/docs/... on GitHub Pages).
 export const docsRoute = `/`;
 export const docsImageRoute = `${pathPrefix}/og`;
-export const docsContentRoute = `${pathPrefix}/llms.mdx`;
+export const docsContentRoute = `${pathPrefix}/llms`;
 export const gitConfig = {
   user: 'ton-org',
   repo: 'docs',
@@ -31,5 +32,13 @@ export function withBasePath(src: string): string {
   // already prefixed
   if (src === pathPrefix || src.startsWith(pathPrefix + '/')) return src;
   //
+  return pathPrefix + src;
+}
+
+export function withBaseUrl(src: string): string {
+  // locally or not on GitHub Pages
+  if (!urlPrefix) return src;
+  // external, relative, or data:
+  if (!src.startsWith('/') || src.startsWith('//')) return src;
   return pathPrefix + src;
 }

--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -25,14 +25,15 @@ export function toPascalCase(name: string): string {
 }
 
 export function withBasePath(src: string): string {
+  const normalizedPrefix = pathPrefix.length > 1 ? pathPrefix.replace(/\/+$/, '') : pathPrefix;
   // locally or not on GitHub Pages
-  if (!pathPrefix) return src;
+  if (!normalizedPrefix) return src;
   // external, relative, or data:
   if (!src.startsWith('/') || src.startsWith('//')) return src;
   // already prefixed
-  if (src === pathPrefix || src.startsWith(pathPrefix + '/')) return src;
+  if (src === normalizedPrefix || src.startsWith(normalizedPrefix + '/')) return src;
   //
-  return pathPrefix + src;
+  return normalizedPrefix + src;
 }
 
 export function withBaseUrl(src: string): string {
@@ -40,5 +41,5 @@ export function withBaseUrl(src: string): string {
   if (!urlPrefix) return src;
   // external, relative, or data:
   if (!src.startsWith('/') || src.startsWith('//')) return src;
-  return pathPrefix + src;
+  return urlPrefix + src;
 }

--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -14,10 +14,22 @@ export const gitConfig = {
 export const ghPagesUrl = `https://${gitConfig.user}.github.io/${gitConfig.repo}`;
 
 // Functions
+
 export function toPascalCase(name: string): string {
   return name
     .split(/[-_\s]+/)
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join('');
+}
+
+export function withBasePath(src: string): string {
+  // locally or not on GitHub Pages
+  if (!pathPrefix) return src;
+  // external, relative, or data:
+  if (!src.startsWith('/') || src.startsWith('//')) return src;
+  // already prefixed
+  if (src === pathPrefix || src.startsWith(pathPrefix + '/')) return src;
+  //
+  return pathPrefix + src;
 }

--- a/src/lib/source.ts
+++ b/src/lib/source.ts
@@ -128,16 +128,22 @@ export function getPageMarkdownUrl(page: (typeof source)['$inferPage']) {
 }
 
 function getLLMContentPath(url: string) {
-  return `${docsContentRoute}` + url.replace(/\/*$/, '') + '/content.md';
+  const match = url.match(/^([^?#]*)(?:[?#].*)?$/);
+  const pathname = (match?.[1] ?? url).replace(/\/+$/, '');
+  return `${docsContentRoute}${pathname}/content.md`;
 }
 
 export function processLLMLinks(md: string): string {
   return (
     md
       // ](/…) inline + ![](/…)
-      .replace(/(\]\()(\/[^)\s]*)/g, (_m, p, url) => p + getLLMContentPath(url))
+      .replace(/(\]\()(\/[^)\s]*)/g, (m, p, url) =>
+        url.startsWith('//') ? m : p + getLLMContentPath(url),
+      )
       // []: /… reference defs
-      .replace(/(\]:\s+)(\/\S*)/g, (_m, p, url) => p + getLLMContentPath(url))
+      .replace(/(\]:\s+)(\/\S*)/g, (m, p, url) =>
+        url.startsWith('//') ? m : p + getLLMContentPath(url),
+      )
   );
 }
 

--- a/src/lib/source.ts
+++ b/src/lib/source.ts
@@ -3,7 +3,7 @@ import { docs } from 'collections/server';
 import { loader } from 'fumadocs-core/source';
 import { openapiPlugin } from 'fumadocs-openapi/server';
 import { icons } from 'lucide-react';
-import { docsContentRoute, docsImageRoute, docsRoute, toPascalCase, withBasePath } from './shared';
+import { docsContentRoute, docsImageRoute, docsRoute, toPascalCase, withBaseUrl } from './shared';
 
 // NOTE: Consider using the following as a plugin instead:
 //       import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
@@ -127,18 +127,22 @@ export function getPageMarkdownUrl(page: (typeof source)['$inferPage']) {
   };
 }
 
-function prefixProcessedMarkdownLinks(md: string): string {
+function getLLMContentPath(url: string) {
+  return `${docsContentRoute}` + url.replace(/\/*$/, '') + '/content.md';
+}
+
+export function processLLMLinks(md: string): string {
   return (
     md
       // ](/…) inline + ![](/…)
-      .replace(/(\]\()(\/[^)\s]*)/g, (_m, p, url) => p + withBasePath(url))
+      .replace(/(\]\()(\/[^)\s]*)/g, (_m, p, url) => p + getLLMContentPath(url))
       // []: /… reference defs
-      .replace(/(\]:\s+)(\/\S*)/g, (_m, p, url) => p + withBasePath(url))
+      .replace(/(\]:\s+)(\/\S*)/g, (_m, p, url) => p + getLLMContentPath(url))
   );
 }
 
 export async function getLLMText(page: (typeof source)['$inferPage']) {
-  const processed = prefixProcessedMarkdownLinks(await page.data.getText('processed'));
+  const processed = processLLMLinks(await page.data.getText('processed'));
 
-  return `# ${page.data.title} (${page.url})\n\n${processed}`;
+  return `# ${page.data.title} (${withBaseUrl(getLLMContentPath(page.url))})\n\n${processed}`;
 }

--- a/src/lib/source.ts
+++ b/src/lib/source.ts
@@ -3,7 +3,7 @@ import { docs } from 'collections/server';
 import { loader } from 'fumadocs-core/source';
 import { openapiPlugin } from 'fumadocs-openapi/server';
 import { icons } from 'lucide-react';
-import { docsContentRoute, docsImageRoute, docsRoute, toPascalCase } from './shared';
+import { docsContentRoute, docsImageRoute, docsRoute, toPascalCase, withBasePath } from './shared';
 
 // NOTE: Consider using the following as a plugin instead:
 //       import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
@@ -127,10 +127,18 @@ export function getPageMarkdownUrl(page: (typeof source)['$inferPage']) {
   };
 }
 
+function prefixProcessedMarkdownLinks(md: string): string {
+  return (
+    md
+      // ](/…) inline + ![](/…)
+      .replace(/(\]\()(\/[^)\s]*)/g, (_m, p, url) => p + withBasePath(url))
+      // []: /… reference defs
+      .replace(/(\]:\s+)(\/\S*)/g, (_m, p, url) => p + withBasePath(url))
+  );
+}
+
 export async function getLLMText(page: (typeof source)['$inferPage']) {
-  const processed = await page.data.getText('processed');
+  const processed = prefixProcessedMarkdownLinks(await page.data.getText('processed'));
 
-  return `# ${page.data.title} (${page.url})
-
-${processed}`;
+  return `# ${page.data.title} (${page.url})\n\n${processed}`;
 }


### PR DESCRIPTION
Follow-up to #2203 and #2217
Touches on #2219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side video rendering with base-path rewriting for `src`/`poster`.
  * Expanded icon aliases and improved MDX media handling (zoomable images with link-aware behavior).
* **Bug Fixes**
  * Improved 404 page layout and CTA wording (“Home page”, “Get support”).
  * Updated post-build link and asset rewriting rules, including spec file loading and improved LLM markdown/link rewriting.
* **Refactor**
  * Refreshed callout styling to use a unified theme color variable.
* **Chores**
  * Increased build memory limit for Node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->