### PR TITLE
chore: update the repository user to `ton-blockchain`

### DIFF
--- a/.github/workflows/deployer.yml
+++ b/.github/workflows/deployer.yml
@@ -100,7 +100,7 @@ jobs:
 
   deploy:
     name: "Docs deploy"
-    if: github.event_name != 'pull_request' && (github.ref_name == 'pages' || github.ref_name == 'main') && github.repository == 'ton-org/docs'
+    if: github.event_name != 'pull_request' && (github.ref_name == 'pages' || github.ref_name == 'main') && github.repository == 'ton-blockchain/docs'
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-deploy

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# Default to the documentation team when there are no specific matches
-# * @ton-org/docs
-
-##
-# CI
-##
-
-# /.github/ @novusnota

--- a/content/contribute/snippets/aside.mdx
+++ b/content/contribute/snippets/aside.mdx
@@ -58,7 +58,7 @@ Override the default aside titles by using the [`title`](#title) attribute.
 
 ## `<Aside>` props
 
-**Implementation:** [`aside.jsx`](https://github.com/ton-org/docs/blob/35698de907d234c950c47d74f9120bcaa120828a/snippets/aside.jsx)
+**Implementation:** [`aside.jsx`](https://github.com/ton-blockchain/docs/blob/35698de907d234c950c47d74f9120bcaa120828a/snippets/aside.jsx)
 
 The `<Aside>` component accepts the following props:
 

--- a/content/contribute/snippets/filetree.mdx
+++ b/content/contribute/snippets/filetree.mdx
@@ -106,7 +106,7 @@ Specify the structure of files and directories inside the [`items` property](#it
 
 ## `<FileTree>` props
 
-**Implementation:** [`filetree.jsx`](https://github.com/ton-org/docs/blob/main/snippets/filetree.jsx)
+**Implementation:** [`filetree.jsx`](https://github.com/ton-blockchain/docs/blob/main/snippets/filetree.jsx)
 
 The `<FileTree>` component accepts the following props:
 

--- a/content/contribute/snippets/image.mdx
+++ b/content/contribute/snippets/image.mdx
@@ -62,7 +62,7 @@ Show images using the `<Image>` component.
 
 ## `<Image>` props
 
-**Implementation:** [`image.jsx`](https://github.com/ton-org/docs/blob/main/snippets/image.jsx)
+**Implementation:** [`image.jsx`](https://github.com/ton-blockchain/docs/blob/main/snippets/image.jsx)
 
 The `<Image>` component accepts the following props:
 

--- a/next.config.static.ts
+++ b/next.config.static.ts
@@ -58,7 +58,7 @@ const config: NextConfig = {
           : 'unknown',
     NEXT_PUBLIC_BASE_URL: resolveBaseUrl(),
     NEXT_PUBLIC_BASE_PATH: resolveBasePath() ?? '',
-    NEXT_GIT_USER: gitRepoMatch?.at(1) ?? 'ton-org',
+    NEXT_GIT_USER: gitRepoMatch?.at(1) ?? 'ton-blockchain',
     NEXT_GIT_REPO: gitRepoMatch?.at(2) ?? 'docs',
     NEXT_GIT_BRANCH: 'main',
   },

--- a/scripts/check-redirects.mjs
+++ b/scripts/check-redirects.mjs
@@ -142,7 +142,7 @@ const checkExist = (config) => {
   const pathIsSpecial = (path) => {
     // Links
     if (path.startsWith('http')) {
-      if (path.includes('github.com/ton-org/docs/issues')) {
+      if (path.includes('github.com/ton-blockchain/docs/issues')) {
         specialDestinationsExist.issues = true;
       } else if (
         path.startsWith('https://github.com/') ||

--- a/src/lib/shared.ts
+++ b/src/lib/shared.ts
@@ -8,7 +8,7 @@ export const docsRoute = `/`;
 export const docsImageRoute = `/og`;
 export const docsContentRoute = `/llms`;
 export const gitConfig = {
-  user: process.env.NEXT_GIT_USER ?? 'ton-org',
+  user: process.env.NEXT_GIT_USER ?? 'ton-blockchain',
   repo: process.env.NEXT_GIT_REPO ?? 'docs',
   branch: process.env.NEXT_GIT_BRANCH ?? 'main',
 };


### PR DESCRIPTION
Yay, TON docs are in the primary TON org :)