### PR TITLE
feat(payments): add a how-to guide for self-hosted Gram and USDT payment processor setup for exchanges and payment services

### DIFF
--- a/content/applications/payments/jettons.mdx
+++ b/content/applications/payments/jettons.mdx
@@ -5,6 +5,8 @@ sidebarTitle: "Jettons"
 
 Processing jetton payments requires understanding TON's sharded token architecture. Unlike single-contract token systems, each jetton type consists of a master contract and individual wallet contracts for each holder.
 
+For example, USDT on TON is implemented as a jetton, and its master (minter) contract address is `EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs`.
+
 <Callout type="note">
   Jettons are fungible tokens on TON. Each jetton has a master contract (minter) and separate wallet contracts for every holder. Read more in [How Jettons Work](/contracts/standard/tokens/jettons/how-it-works).
 </Callout>

--- a/content/applications/payments/meta.json
+++ b/content/applications/payments/meta.json
@@ -4,6 +4,7 @@
   "pages": [
     "overview",
     "gram",
-    "jettons"
+    "jettons",
+    "setup"
   ]
 }

--- a/content/applications/payments/overview.mdx
+++ b/content/applications/payments/overview.mdx
@@ -5,9 +5,13 @@ sidebarTitle: "Overview"
 
 Payment processing on TON refers to monitoring and handling blockchain transactions for business applications. While simple use cases can rely entirely on smart contracts, most real-world payment systems require off-chain processing to track deposits, manage user balances, send confirmations, and integrate with existing business logic.
 
+<Callout type="note">
+  See how to set up an example [self-hosted payment processor](/applications/payments/setup) for Gram and USDT (on TON) deposits and withdrawals.
+</Callout>
+
 ## On-chain vs off-chain processing
 
-On-chain processing executes all payment logic within smart contracts. When a user sends Grams or Jettons to a contract, the contract immediately processes the payment and updates state. This works for simple scenarios like direct peer-to-peer transfers or automated market makers, but becomes impractical when you need user accounts, payment history, refunds, or integration with external systems.
+On-chain processing executes all payment logic within smart contracts. When a user sends Grams or Jettons (including USDT on TON mainnet) to a contract, the contract immediately processes the payment and updates state. This works for simple scenarios like direct peer-to-peer transfers or automated market makers, but becomes impractical when you need user accounts, payment history, refunds, or integration with external systems.
 
 Off-chain processing monitors blockchain state changes from outside the network. Your application observes transactions, verifies their validity, updates internal databases, and triggers business logic. Exchanges, merchants, and payment processors use this approach because it provides flexibility to implement complex workflows, maintain user data, and integrate with traditional systems.
 
@@ -34,11 +38,11 @@ Read more about [how Jettons work](/contracts/standard/tokens/jettons/how-it-wor
 
 Three main approaches exist for implementing payment processing on TON:
 
-**Self-built solution**: You run your own service that connects to some TON API or [liteserver](/api/overview), monitors blocks for relevant transactions, and maintains a database of payment events. This requires building infrastructure to fetch blocks, parse transactions, handle reconnections, and manage state. The advantage is complete control over the implementation and no dependency on external services. The disadvantage is significant development and maintenance effort.
+- **Self-built solution**: You run your own service that connects to some TON API or [liteserver](/api/overview), monitors blocks for relevant transactions, and maintains a database of payment events. This requires building infrastructure to fetch blocks, parse transactions, handle reconnections, and manage state. The advantage is complete control over the implementation and no dependency on external services. The disadvantage is significant development and maintenance effort.
 
-**Self-hosted payment processor**: Open-source payment processors like [Bicycle](https://github.com/gobicycle/bicycle) and [Spice harvester](https://github.com/txsociety/spice-harvester) provide ready-to-deploy solutions that handle blockchain monitoring and expose APIs for your application. You deploy the processor on your infrastructure, configure it for your wallet addresses and asset types, and consume its API to track payments. This balances control with reduced development effort, though you still manage the infrastructure.
+- **Self-hosted payment processor**: Open-source payment processors like [Bicycle](/applications/payments/bicycle) and [Spice harvester](https://github.com/txsociety/spice-harvester) provide ready-to-deploy solutions that handle blockchain monitoring and expose APIs for your application. You deploy the processor on your infrastructure, configure it for your wallet addresses and asset types, and consume its API to track payments. This balances control with reduced development effort, though you still manage the infrastructure.
 
-**Third-party payment processor**: External services handle all blockchain interaction and provide simple APIs or webhooks for payment notifications. You integrate their SDK or API, and they manage infrastructure, monitoring, and maintenance. This is fastest to implement but introduces dependency on the service provider and typically involves transaction fees.
+- **Third-party payment processor**: External services handle all blockchain interaction and provide simple APIs or webhooks for payment notifications. You integrate their SDK or API, and they manage infrastructure, monitoring, and maintenance. This is fastest to implement but introduces dependency on the service provider and typically involves transaction fees.
 
 The choice depends on your requirements for control, development resources, and operational complexity. High-volume applications often build custom solutions, while smaller merchants prefer third-party services.
 

--- a/content/applications/payments/setup.mdx
+++ b/content/applications/payments/setup.mdx
@@ -1,0 +1,459 @@
+---
+title: "How to set up a self-hosted payment processor using Bicycle"
+sidebarTitle: "Self-hosted setup"
+---
+
+<Callout type="caution">
+  This guide shows one of the possible ways to set up Gram and USDT (on TON) payments in business applications. For more info and alternative approaches, see the [payment processing overview](/applications/payments/overview).
+</Callout>
+
+[Bicycle](https://github.com/gobicycle/bicycle) is a self-hosted payment processor for TON. It runs next to an exchange, custodial wallet, merchant backend, or payment service and provides a REST API for:
+
+- Reusable per-user deposit addresses
+- Gram deposits and withdrawals
+- Jetton deposits and withdrawals, including USDT on TON
+- Hot-wallet aggregation and optional cold-wallet sweeps
+- Webhooks or RabbitMQ notifications
+
+Use Bicycle to show one deposit address per user and currency, credit deposits automatically, and submit withdrawals through one backend API.
+
+<Callout type="caution">
+  Bicycle controls a hot wallet from `SEED`. Do **not** withdraw manually from this hot wallet outside Bicycle. The processor tracks balances, internal sweeps, and withdrawal state in its database — bypassing it can make the service state inconsistent.
+</Callout>
+
+## Architecture
+
+```mermaid
+graph LR
+  U[User wallet] --> DA[User deposit address]
+  DA --> HW[Bicycle hot wallet]
+  HW --> CW[Cold wallet]
+  HW --> W[User withdrawal wallet]
+  B[Bicycle API] --> DB[(PostgreSQL)]
+  B --> LS[Liteserver]
+  B --> WH[Webhooks or RabbitMQ]
+  DB --> VIS[Grafana or Prometheus]
+```
+
+Bicycle creates deposit addresses from the hot-wallet seed and stores the mapping to an application `user_id`. For Gram, users deposit to a TON wallet address. For USDT, users deposit to a proxy owner address that owns the user's USDT jetton wallet. Bicycle scans the relevant shard blocks, records deposits, sweeps balances to the hot wallet when thresholds are met, and sends withdrawals from the hot wallet.
+
+The application does not need to parse comments, generate wallet contracts, scan blocks, or build jetton transfer messages. The backend calls Bicycle and stores Bicycle IDs in the application ledger.
+
+## Prerequisites
+
+- Linux-based OS with `jq` and `curl` installed
+- [Docker Engine](https://docs.docker.com/engine/install/) 24 or later with Docker Compose v2
+- A 24-word seed phrase for the Bicycle hot wallet
+- Enough Gram on the hot wallet to pay fees and deploy/sweep deposit wallets
+- A cold wallet address for automatic cold-wallet sweeps
+
+<Callout type="caution">
+  Test the full flow on testnet first. Note that `IS_TESTNET=true` only controls address validation inside Bicycle — it does **not** prove that the liteserver is testnet.
+</Callout>
+
+## 1. Clone and build Bicycle
+
+```bash
+git clone https://github.com/gobicycle/bicycle.git
+cd bicycle
+make -f Makefile
+```
+
+The existing Bicycle `docker-compose.yml` can start PostgreSQL, the processor, Grafana, Prometheus, and RabbitMQ. For a minimal production-like setup, start only PostgreSQL and `payment-processor`.
+
+## 2. Choose a liteserver
+
+Bicycle connects to a liteserver over Abstract Datagram Network Layer (ADNL). Either use a [public liteserver with proof verification enabled](#option-a-public-liteserver-with-proofs), or run a [self-hosted liteserver](#option-b-local-liteserver-with-official-docker-image) next to Bicycle.
+
+### Option A: Public liteserver with proofs
+
+Use this path for a short setup. Fetch the current public liteserver list from the network config and extract one endpoint into the Bicycle `.env` file:
+
+```bash
+curl -fsSL https://ton-blockchain.github.io/global.config.json \
+  | jq -r '
+    def ntoa:
+      (if . < 0 then . + 4294967296 else . end) as $ip
+      | [($ip / 16777216 | floor) % 256,
+         ($ip / 65536 | floor) % 256,
+         ($ip / 256 | floor) % 256,
+         $ip % 256]
+      | join(".");
+    .liteservers[0]
+    | "LITESERVER=\(.ip | ntoa):\(.port)\nLITESERVER_KEY='\''\(.id.key)'\''"
+  ' >> .env
+```
+
+Then enable proof checking:
+
+```bash
+cat >> .env <<'EOF'
+PROOF_CHECK_ENABLED=true
+NETWORK_CONFIG_URL=https://ton-blockchain.github.io/global.config.json
+EOF
+```
+
+For testnet, use `https://ton-blockchain.github.io/testnet-global.config.json` and set `IS_TESTNET=true`.
+
+<Callout type="caution">
+  Public liteservers are shared infrastructure. Keep `PROOF_CHECK_ENABLED=true` and set a conservative `LITESERVER_RATE_LIMIT`.
+
+  Consider setting up a [dedicated liteserver](#option-b-local-liteserver-with-official-docker-image) for production payment volume.
+</Callout>
+
+### Option B: Local liteserver with official Docker image
+
+<Callout type="caution">
+  Ensure the server meets the [minimal hardware requirements](/nodes/cpp/run-liteserver#1-1-minimal-hardware-requirements) for running a liteserver node.
+</Callout>
+
+Use this path to run Bicycle and the liteserver on the same host. Put this compose file next to Bicycle's `docker-compose.yml`:
+
+```yaml title="docker-compose.liteserver.yml"
+services:
+  ton-node:
+    image: ghcr.io/ton-blockchain/ton:latest
+    container_name: ton_liteserver
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - /var/ton-work/db:/var/ton-work/db
+    environment:
+      PUBLIC_IP: ${PUBLIC_IP}
+      GLOBAL_CONFIG_URL: https://ton-blockchain.github.io/global.config.json
+      DUMP_URL: https://dump.ton.org/dumps/latest.tar.lz
+      LITESERVER: "true"
+      LITE_PORT: "30003"
+      VALIDATOR_PORT: "30001"
+      QUIC_PORT: "31001"
+      CONSOLE_PORT: "30002"
+      STATE_TTL: "86400"
+      ARCHIVE_TTL: "2592000"
+```
+
+Start it:
+
+```bash
+# One of the ways to check the public IP of the server.
+# If it is known ahead of time, manually specify it here.
+export PUBLIC_IP=$(curl -4 -fsSL ifconfig.me)
+docker compose -f docker-compose.liteserver.yml up -d ton-node
+
+# Follow the logs to check the status.
+docker logs -f ton_liteserver
+```
+
+After `/var/ton-work/db/config.json` is created, append the local liteserver endpoint to Bicycle's `.env`:
+
+```bash
+jq -r '
+  .liteservers[0]
+  | "LITESERVER=host.docker.internal:\(.port)\nLITESERVER_KEY='\''\(.id.key)'\''"
+' /var/ton-work/db/config.json >> .env
+```
+
+Add host access to the `payment-processor` service in Bicycle's compose file when Bicycle uses Docker's bridge network:
+
+```yaml title="docker-compose.yml"
+services:
+  payment-processor:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
+
+For node setup, hardware requirements, firewall, sync, and maintenance details, see [Run a liteserver](/nodes/cpp/run-liteserver). The official Docker image uses the same node software. The key settings above are `LITESERVER=true`, `LITE_PORT`, a public `PUBLIC_IP`, and persistent `/var/ton-work/db` storage.
+
+## 3. Configure assets
+
+Create `.env` file in the Bicycle directory:
+
+```bash title=".env"
+# PostgreSQL setup
+POSTGRES_DB=payment_processor
+POSTGRES_USER=payment_processor
+POSTGRES_PASSWORD=<POSTGRES_PASSWORD>
+POSTGRES_READONLY_PASSWORD=<POSTGRES_READONLY_PASSWORD>
+DB_URI=postgres://payment_processor:<POSTGRES_PASSWORD>@payment_processor_db:5432/payment_processor
+
+# Bicycle's REST API port
+API_PORT=8081
+# Bicycle's Bearer token for REST API
+API_TOKEN=<API_TOKEN>
+
+# Seed phrase for the main hot wallet, 12 or 24 word mnemonic compatible with standard TON wallets
+SEED=<SEED_PHRASE>
+
+# TON address of the cold wallet
+COLD_WALLET=<COLD_WALLET_ADDRESS>
+
+# Cutoffs in nanograms format:
+#   hot_wallet_min_balance:hot_wallet_max_balance:min_withdrawal_amount:hot_wallet_residual_balance
+TON_CUTOFFS=1000000000:100000000000:1000000000:95000000000
+
+# List of jettons to be processed by the service; set to USDTs only
+JETTONS=USDT:EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs:100000000000:10000000:95000000000
+
+# USDTs only exist on mainnet!
+IS_TESTNET=false
+
+# Miscellaneous, refer to Bicycle's README.md for details
+DEPOSIT_SIDE_BALANCE=true
+FORWARD_TON_AMOUNT=1
+LITESERVER_RATE_LIMIT=25
+LITESERVER_MAX_RETRIES=10
+LITESERVER_BASE_RETRY_DELAY=100
+ALLOWABLE_LAG=40
+```
+
+Configure the processor container to receive all Bicycle `.env` vars, not only the variables already listed in the upstream compose file:
+
+```yaml title="docker-compose.yml"
+services:
+  payment-processor:
+    env_file:
+      - .env
+```
+
+`TON_CUTOFFS` uses nanograms:
+
+| Position                      | Meaning                                                   |
+| ----------------------------- | --------------------------------------------------------- |
+| `hot_wallet_min_balance`      | Minimum hot-wallet Gram balance required on startup       |
+| `hot_wallet_max_balance`      | Balance that triggers a cold-wallet sweep                 |
+| `minimum_withdrawal_amount`   | Minimum deposit-wallet balance to sweep to the hot wallet |
+| `hot_wallet_residual_balance` | Balance left after a cold-wallet sweep                    |
+
+`JETTONS` uses jetton base units. USDT on TON has 6 decimals, so `1000000` means 1 USDT:
+
+| Position             | Meaning                                                 |
+| -------------------- | ------------------------------------------------------- |
+| `USDT`               | Currency code used in Bicycle API requests              |
+| [`EQCx...sDs`][usdt] | [USDT jetton master address][usdt] on mainnet           |
+| `100000000000`       | Sweep hot-wallet excess above 100,000 USDT              |
+| `10000000`           | Sweep a deposit wallet after it holds more than 10 USDT |
+| `95000000000`        | Leave 95,000 USDT after a cold-wallet sweep             |
+
+<Callout
+  type="danger"
+  title="Verify the jetton master (minter)"
+>
+  Never accept jettons by symbol or metadata alone — only accept an allow-listed master contract address. Verify the USDT jetton master address before mainnet launch.
+
+  USDTs only exist on the mainnet.
+</Callout>
+
+For information about the other environment variables, refer to the Bicycle's `README.md` file.
+
+## 4. Start Bicycle
+
+For a minimal production setup, start only `payment-postgres` (PostgreSQL) and `payment-processor` (Bicycle itself):
+
+```bash
+docker compose up -d payment-postgres
+docker compose up -d payment-processor
+```
+
+<Callout type="note">
+  Optional available services include: `payment-grafana` (Grafana), `payment-prometheus` (Prometheus), and `payment-rabbitmq` (RabbitMQ).
+</Callout>
+
+Check sync:
+
+```bash
+curl -sS http://127.0.0.1:8081/v1/system/sync | jq
+```
+
+Example of an expected response when Bicycle is caught up:
+
+```json
+{
+  "is_synced": true,
+  "last_block_gen_utime": 1719306580
+}
+```
+
+## 5. Create deposit addresses
+
+Create one Gram deposit address for a user:
+
+```bash
+curl -sS http://127.0.0.1:8081/v1/address/new \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id":"user-1001","currency":"TON"}' | jq
+```
+
+Create one USDT deposit address for the same user:
+
+```bash
+curl -sS http://127.0.0.1:8081/v1/address/new \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id":"user-1001","currency":"USDT"}' | jq
+```
+
+Store the returned address in the application database and show it to the user. Users do not need to enter comments or invoice IDs.
+
+To list all addresses later:
+
+```bash
+curl -sS "http://127.0.0.1:8081/v1/address/all?user_id=user-1001" \
+  -H "Authorization: Bearer $API_TOKEN" | jq
+```
+
+## 6. Credit deposits
+
+If `DEPOSIT_SIDE_BALANCE=true`, Bicycle credits deposits when it observes income on the deposit address. Query the user's total credited income:
+
+```bash
+curl -sS "http://127.0.0.1:8081/v1/income?user_id=user-1001" \
+  -H "Authorization: Bearer $API_TOKEN" | jq
+```
+
+Fetch deposit history for reconciliation:
+
+```bash
+curl -sS "http://127.0.0.1:8081/v1/deposit/history?user_id=user-1001&currency=USDT&limit=20&offset=0&sort_order=desc" \
+  -H "Authorization: Bearer $API_TOKEN" | jq
+```
+
+Look up a deposit by transaction hash when handling support tickets:
+
+```bash
+curl -sS "http://127.0.0.1:8081/v1/deposit/income?tx_hash=<TX_HASH>" \
+  -H "Authorization: Bearer $API_TOKEN" | jq
+```
+
+## 7. Send manual withdrawals
+
+<Callout type="caution">
+  Bicycle controls a hot wallet from `SEED`. Do **not** withdraw manually from this hot wallet **outside** Bicycle. The processor tracks balances, internal sweeps, and withdrawal state in its database — bypassing it can make the service state inconsistent.
+</Callout>
+
+Use a unique `query_id` per user withdrawal. Bicycle rejects duplicate `(user_id, query_id)` pairs.
+
+Withdraw 1 Gram:
+
+```bash
+# Replace <RECIPIENT_ADDRESS> with desired TON wallet address
+curl -sS http://127.0.0.1:8081/v1/withdrawal/send \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "user-1001",
+    "query_id": "wd-ton-000001",
+    "currency": "TON",
+    "amount": 1000000000,
+    "destination": "<RECIPIENT_ADDRESS>",
+    "comment": "withdrawal wd-ton-000001"
+  }' | jq
+```
+
+Withdraw 25 USDT:
+
+```bash
+# Replace <RECIPIENT_ADDRESS> with desired TON wallet address
+curl -sS http://127.0.0.1:8081/v1/withdrawal/send \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "user-1001",
+    "query_id": "wd-usdt-000001",
+    "currency": "USDT",
+    "amount": 25000000,
+    "destination": "<RECIPIENT_ADDRESS>",
+    "comment": "withdrawal wd-usdt-000001"
+  }' | jq
+```
+
+Check the withdrawal status:
+
+```bash
+# Replace <WITHDRAWAL_ID> with the `query_id` previously submitted to `/v1/withdrawal/send`
+curl -sS "http://127.0.0.1:8081/v1/withdrawal/status?id=<WITHDRAWAL_ID>" \
+  -H "Authorization: Bearer $API_TOKEN" | jq
+```
+
+Statuses are `pending`, `processing`, `processed`, and `failed`. Treat `processed` as the terminal success state in the application ledger.
+
+## 8. Enable notifications
+
+### Option A: Webhook endpoint
+
+Extend the `.env` file with webhook variables before starting the `payment-processor` service:
+
+```bash
+cat >> .env <<'EOF'
+# When set, Bicycle will send webhooks to the specified endpoint
+WEBHOOK_ENDPOINT=https://payments.example.com/ton/bicycle/webhook
+# Bearer token for the webhook requests — leave unset when unused
+# WEBHOOK_TOKEN=<WEBHOOK_TOKEN>
+EOF
+```
+
+Start or restart the service:
+
+```bash
+docker compose up -d payment-processor
+```
+
+Bicycle sends deposit notifications as JSON:
+
+```json
+{
+  "deposit_address": "<DEPOSIT_ADDRESS>",
+  "time": 1719306580,
+  "amount": "25000000",
+  "source_address": "<SOURCE_ADDRESS>",
+  "comment": "optional comment",
+  "tx_hash": "f9b9e7efd3a38da318a894576499f0b6af5ca2da97ccd15c5f1d291a808a0ebf",
+  "user_id": "user-1001"
+}
+```
+
+The webhook handler should be idempotent by `tx_hash`, verify `user_id` and `deposit_address` against application records, credit the internal ledger once, and return HTTP `200` with an empty body. Bicycle stops after repeated unsuccessful webhook delivery, so monitor processor logs and alerts.
+
+### Option B: RabbitMQ
+
+Extend the `.env` file with RabbitMQ variables and start the `payment-rabbitmq` service before starting the `payment-processor`:
+
+```bash
+cat >> .env <<'EOF'
+# When true, Bicycle will send incoming notiications to the RabbitMQ queue
+QUEUE_ENABLED=true
+
+# URI for client connections to the queue
+QUEUE_URI=amqp://guest:guest@payment_rabbitmq:5672/
+
+# Name of the exchange
+QUEUE_NAME=<QUEUE_NAME>
+EOF
+```
+
+Start or restart the services:
+
+```bash
+docker compose up -d payment-rabbitmq
+docker compose up -d payment-processor
+```
+
+## Operational checklist
+
+- Keep `SEED`, `API_TOKEN`, database credentials, and webhook tokens in a secret manager.
+- Expose Bicycle's API **only** to the application backend, not to the public Internet.
+- Keep enough Gram on the hot wallet for fees, jetton notifications, and deposit sweeps.
+- Keep a separate cold wallet whose seed is **never** loaded into Bicycle.
+- Always use `PROOF_CHECK_ENABLED=true` for public or rented liteservers.
+- Monitor `/v1/system/sync`, `/metrics`, hot-wallet balances, failed withdrawals, and webhook delivery.
+- Reconcile the application ledger with `/v1/deposit/history` and `/v1/withdrawal/status`.
+- Test mistaken-transfer recovery with `/v1/withdrawal/service/ton` and `/v1/withdrawal/service/jetton` before production.
+
+## See also
+
+- [Payment processing overview](/applications/payments/overview)
+- [Gram payments processing](/applications/payments/gram)
+- [Jetton payments processing](/applications/payments/jettons)
+- [Guide for running a liteserver](/nodes/cpp/run-liteserver)
+- [Liteserver proof verification](/foundations/proofs/verifying-liteserver-proofs)
+
+[usdt]: https://tonscan.org/jetton/EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs

--- a/content/applications/ton-pay/api-reference.mdx
+++ b/content/applications/ton-pay/api-reference.mdx
@@ -3,7 +3,7 @@ title: "TON Pay API reference"
 sidebarTitle: "API reference"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 
@@ -119,7 +119,7 @@ type CompletedTonPayTransferInfo = {
 };
 ```
 
-- `status`: `pending`, `success`, or `error`;
+- `status`: `pending`, `success`, or `failed`;
 - `errorCode`: TON Pay error codes in [Check status and retrieve info](/applications/ton-pay/payment-integration/status-info).
 
 ### `APIOptions`
@@ -138,8 +138,8 @@ type APIOptions = {
 
 ```ts
 import { TON, USDT } from "@ton-pay/api";
-// GRAM: the string constant "GRAM" (use for Gram transfers)
-// USDT: mainnet USDT jetton master address
+// TON: native Gram transfer identifier used by TON Pay
+// USDT: mainnet USDt jetton master address
 ```
 
 <Callout

--- a/content/applications/ton-pay/invoices.mdx
+++ b/content/applications/ton-pay/invoices.mdx
@@ -1,0 +1,375 @@
+---
+title: "How to set up invoice Gram and USDT payments with TON Pay"
+sidebarTitle: "Invoices"
+---
+
+<Callout type="caution">
+  This guide implements invoice deposits. For static per-user deposit addresses, use [direct payment processing](/applications/payments/overview) **instead** of TON Pay.
+</Callout>
+
+<Callout type="caution">
+  TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
+</Callout>
+
+Add mainnet invoice-based Gram (`GRAM`) and USDT on TON (`USDT` jetton) deposits and withdrawals to a dApp or service with the smallest TON-specific surface:
+
+- deposits: TON Pay creates a user-signed transfer and sends settlement webhooks;
+- withdrawals: an existing custody, wallet, or payout service signs outbound transfers.
+
+This flow does not require parsing cells, messages, or jetton transfer bodies in the service backend.
+
+<Callout
+  type="danger"
+  title="Funds at risk"
+>
+  Mainnet transfers are irreversible. Validate the same integration on testnet before moving production funds. On mainnet, start with small transfers, settle each transaction hash once, and require manual review for amount, asset, sender, or recipient mismatches.
+</Callout>
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/en/download/) 20 or later LTS.
+- A TON Pay merchant API key.
+- A TON Pay webhook secret.
+- A mainnet receiving wallet controlled by the service.
+- A withdrawal signer behind an internal API, custody provider, or [Highload Wallet v3](/contracts/standard/wallets/highload/overview).
+
+## Install the SDK \[step]
+
+```bash
+npm install @ton-pay/api
+```
+
+## Configure assets \[step]
+
+Create one shared asset configuration and reuse it in deposit, webhook, and withdrawal code.
+
+```ts
+export const CHAIN = "mainnet" as const;
+
+export const ASSETS = {
+  GRAM: {
+    code: "GRAM",
+    tonPayAsset: "TON",
+    decimals: 9,
+  },
+  USDT: {
+    code: "USDT",
+    tonPayAsset: "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+    decimals: 6,
+  },
+} as const;
+```
+
+## Add ledger tables \[step]
+
+Use the existing ledger if it already has equivalent fields.
+
+```sql title="Example database tables"
+create table ton_deposits (
+  id text primary key,
+  user_id text not null,
+  asset text not null,
+  amount text not null,
+  sender_addr text not null,
+  recipient_addr text not null,
+  reference text not null unique,
+  body_base64_hash text not null unique,
+  tx_hash text unique,
+  status text not null,
+  created_at timestamptz not null default now(),
+  settled_at timestamptz
+);
+
+create table ton_withdrawals (
+  id text primary key,
+  user_id text not null,
+  asset text not null,
+  amount text not null,
+  recipient_addr text not null,
+  tx_hash text unique,
+  status text not null,
+  created_at timestamptz not null default now(),
+  settled_at timestamptz
+);
+```
+
+## Create deposit invoices \[step]
+
+Expose an authenticated endpoint that creates a TON Pay transfer. The frontend passes the connected wallet address as `senderAddr` and sends `message` through TON Connect.
+
+```ts
+// NOTE: Not runnable — replace db.* calls with the actual database layer
+import { createTonPayTransfer } from "@ton-pay/api";
+import { ASSETS, CHAIN } from "./ton-assets";
+
+// NOTE: Replace with the TON Pay merchant API key
+const TONPAY_API_KEY = "<TONPAY_API_KEY>";
+
+// NOTE: Replace with the receiving wallet on TON mainnet
+const SERVICE_WALLET_ADDR = "<SERVICE_WALLET_ADDR>";
+
+app.post("/api/ton/deposits", requireAuth, async (req, res) => {
+  const { userId } = req.session;
+  const { assetCode, amount, senderAddr } = req.body;
+  const asset = ASSETS[assetCode as keyof typeof ASSETS];
+
+  if (!asset) {
+    return res.status(400).json({ error: "Unsupported asset" });
+  }
+
+  const depositId = crypto.randomUUID();
+  const transfer = await createTonPayTransfer(
+    {
+      amount: Number(amount),
+      asset: asset.tonPayAsset,
+      recipientAddr: SERVICE_WALLET_ADDR,
+      senderAddr,
+      commentToSender: `Deposit ${depositId}`,
+      commentToRecipient: depositId,
+    },
+    {
+      chain: CHAIN,
+      apiKey: TONPAY_API_KEY,
+    }
+  );
+
+  // NOTE: Replace with the actual database layer
+  await db.tonDeposits.insert({
+    id: depositId,
+    userId,
+    asset: asset.code,
+    amount: String(amount),
+    senderAddr,
+    recipientAddr: SERVICE_WALLET_ADDR,
+    reference: transfer.reference,
+    bodyBase64Hash: transfer.bodyBase64Hash,
+    status: "pending",
+  });
+
+  res.json({
+    depositId,
+    reference: transfer.reference,
+    message: transfer.message,
+  });
+});
+```
+
+## Send the deposit from the client \[step]
+
+Use the returned `message` as the only TON-specific object in the client. TON Connect handles wallet selection and signing.
+
+```ts
+// NOTE: Not runnable — adapt `tonConnectUI` to the frontend setup
+async function startTonDeposit(params: {
+  assetCode: "GRAM" | "USDT";
+  amount: string;
+  senderAddr: string;
+}) {
+  const response = await fetch("/api/ton/deposits", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+
+  const { depositId, message } = await response.json();
+
+  await tonConnectUI.sendTransaction({
+    validUntil: Math.floor(Date.now() / 1000) + 300,
+    messages: [message],
+  });
+
+  return depositId;
+}
+```
+
+## Settle deposit webhooks \[step]
+
+Configure TON Pay to call this endpoint after transfer completion. Credit the user ledger only after all checks pass.
+
+```ts
+// NOTE: Not runnable — replace `creditUserOnce` with the actual ledger mutation.
+import { verifySignature, type WebhookPayload } from "@ton-pay/api";
+import { ASSETS } from "./ton-assets";
+
+// NOTE: Replace it with the secret used to verify `X-TonPay-Signature`.
+const TONPAY_WEBHOOK_SECRET = "<TONPAY_WEBHOOK_SECRET>";
+
+app.post(
+  "/webhooks/tonpay",
+  express.raw({ type: "application/json" }),
+  async (req, res) => {
+    const signature = req.header("X-TonPay-Signature") ?? "";
+    const rawBody = req.body.toString("utf8");
+
+    if (!verifySignature(rawBody, signature, TONPAY_WEBHOOK_SECRET)) {
+      return res.status(401).json({ error: "Invalid signature" });
+    }
+
+    const payload = JSON.parse(rawBody) as WebhookPayload;
+
+    if (payload.event !== "transfer.completed") {
+      return res.status(200).json({ ignored: true });
+    }
+
+    const transfer = payload.data;
+    const deposit = await db.tonDeposits.findByReference(transfer.reference);
+
+    if (!deposit || transfer.status !== "success") {
+      return res.status(200).json({ ignored: true });
+    }
+
+    const asset = ASSETS[deposit.asset as keyof typeof ASSETS];
+    const sameAsset = transfer.asset === asset.tonPayAsset;
+    const sameAmount = transfer.amount === deposit.amount;
+    const sameSender = transfer.senderAddr === deposit.senderAddr;
+    const sameRecipient = transfer.recipientAddr === deposit.recipientAddr;
+
+    if (!sameAsset || !sameAmount || !sameSender || !sameRecipient) {
+      await db.tonDeposits.markReview(deposit.id, transfer);
+      return res.status(200).json({ review: true });
+    }
+
+    // NOTE: Replace with the actual ledger mutation
+    await db.transaction(async (tx) => {
+      await tx.tonDeposits.settleOnce(deposit.id, transfer.txHash);
+      await tx.ledger.creditUserOnce({
+        userId: deposit.userId,
+        asset: deposit.asset,
+        amount: deposit.amount,
+        externalId: transfer.txHash,
+      });
+    });
+
+    res.status(200).json({ ok: true });
+  }
+);
+```
+
+## Add withdrawal requests \[step]
+
+Keep TON signing outside the web app. The backend validates the request, locks the user balance, then calls a custody adapter.
+
+```ts
+// NOTE: Not runnable —
+//       implement `custody.sendGram` and `custody.sendJetton`
+//       with the selected signer or provider
+import { ASSETS } from "./ton-assets";
+
+// NOTE: Replace with the internal or provider API key for the withdrawal signer
+const CUSTODY_API_KEY = "<CUSTODY_API_KEY>";
+
+app.post("/api/ton/withdrawals", requireAuth, async (req, res) => {
+  const { userId } = req.session;
+  const { assetCode, amount, recipientAddr } = req.body;
+  const asset = ASSETS[assetCode as keyof typeof ASSETS];
+
+  if (!asset) {
+    return res.status(400).json({ error: "Unsupported asset" });
+  }
+
+  const withdrawalId = crypto.randomUUID();
+
+  // NOTE: Replace with the actual ledger mutation
+  await db.transaction(async (tx) => {
+    await tx.ledger.lockUserBalance({
+      userId,
+      asset: asset.code,
+      amount: String(amount),
+      reason: withdrawalId,
+    });
+
+    await tx.tonWithdrawals.insert({
+      id: withdrawalId,
+      userId,
+      asset: asset.code,
+      amount: String(amount),
+      recipientAddr,
+      status: "queued",
+    });
+  });
+
+  res.json({ withdrawalId, status: "queued" });
+});
+```
+
+## Broadcast withdrawals \[step]
+
+Run a worker that reads queued withdrawals and sends them through the custody adapter. For USDT, the adapter must send a jetton transfer from the service wallet and return the transaction hash.
+
+```ts
+// NOTE: Not runnable — implement custody calls with the selected signer or provider
+async function processTonWithdrawal(withdrawal: TonWithdrawal) {
+  const asset = ASSETS[withdrawal.asset as keyof typeof ASSETS];
+
+  const txHash =
+    asset.code === "GRAM"
+      ? await custody.sendGram({
+          apiKey: CUSTODY_API_KEY,
+          to: withdrawal.recipientAddr,
+          amount: withdrawal.amount,
+        })
+      : await custody.sendJetton({
+          apiKey: CUSTODY_API_KEY,
+          jettonMaster: asset.tonPayAsset,
+          to: withdrawal.recipientAddr,
+          amount: withdrawal.amount,
+          forwardTonAmount: "0.000000001",
+        });
+
+  // NOTE: Replace with the actual ledger mutation
+  await db.tonWithdrawals.markBroadcast(withdrawal.id, txHash);
+}
+```
+
+## Reconcile pending deposits \[step]
+
+Use polling as a fallback when a webhook is missed or delayed.
+
+```ts
+// NOTE: Not runnable — reuse the same `settleDeposit` logic from the webhook handler.
+import { getTonPayTransferByReference } from "@ton-pay/api";
+import { CHAIN } from "./ton-assets";
+
+async function reconcileTonPayDeposits() {
+  const pendingDeposits = await db.tonDeposits.findPending();
+
+  for (const deposit of pendingDeposits) {
+    const transfer = await getTonPayTransferByReference(deposit.reference, {
+      chain: CHAIN,
+      apiKey: TONPAY_API_KEY,
+    });
+
+    if (transfer.status === "success") {
+      await settleDeposit(deposit, transfer);
+    }
+  }
+}
+```
+
+## Reconcile daily \[step]
+
+Run a scheduled job that compares records with TON Pay and the custody provider.
+
+1. Query pending TON Pay deposits by `reference`.
+1. Settle successful deposits that missed the webhook.
+1. Move failed or mismatched deposits to manual review.
+1. Query broadcast withdrawals by `txHash`.
+1. Mark finalized withdrawals as `settled`.
+1. Unlock failed withdrawals and move them to manual review.
+
+## Result
+
+The integration has 4 moving parts:
+
+- `POST /api/ton/deposits` creates a TON Pay payment message.
+- `/webhooks/tonpay` settles deposits after TON Pay confirms them.
+- `POST /api/ton/withdrawals` queues and locks withdrawals.
+- A withdrawal worker sends payouts through the custody adapter.
+
+TON-specific logic stays in TON Pay and the custody adapter. The backend stores orders, verifies fields, updates balances, and reconciles transaction hashes.
+
+## See also
+
+- [How to build a transfer in TON Pay](/applications/ton-pay/payment-integration/transfer)
+- [TON Pay webhooks](/applications/ton-pay/webhooks)
+- [Highload wallets](/contracts/standard/wallets/highload/overview)

--- a/content/applications/ton-pay/meta.json
+++ b/content/applications/ton-pay/meta.json
@@ -4,6 +4,7 @@
   "pages": [
     "overview",
     "quick-start",
+    "invoices",
     "on-ramp",
     "payment-integration",
     "ui-integration",

--- a/content/applications/ton-pay/on-ramp.mdx
+++ b/content/applications/ton-pay/on-ramp.mdx
@@ -3,7 +3,7 @@ title: "On-ramp in TON Pay SDK"
 sidebarTitle: "On-ramp"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 
@@ -39,9 +39,9 @@ When `isOnRampAvailable` is `false`, the "Top up by card" option is hidden. Paym
 
 The SDK supports the following assets for on-ramp top-ups:
 
-| Token          | Master address                                     |
+| Asset          | Master address                                     |
 | :------------- | :------------------------------------------------- |
-| TON            | Native                                             |
+| Gram           | Native (`TON` in TON Pay SDK)                      |
 | USDT           | `EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs` |
 | DOGS           | `EQCvxJy4eG8hyHBFsZ7eePxrRsUQSFE_jpptRAYBmcG_DOGS` |
 | Notcoin        | `EQAvlWFDxGF2lXm67y4yzC17wYKD9A0guwPkMs1gOsM__NOT` |

--- a/content/applications/ton-pay/overview.mdx
+++ b/content/applications/ton-pay/overview.mdx
@@ -3,7 +3,7 @@ title: "TON Pay SDK overview"
 sidebarTitle: "Overview"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 

--- a/content/applications/ton-pay/payment-integration/payments-react.mdx
+++ b/content/applications/ton-pay/payment-integration/payments-react.mdx
@@ -3,7 +3,7 @@ title: "How to send payments using TON Pay React hook"
 sidebarTitle: "Send payments React"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 
@@ -183,7 +183,8 @@ app.post("/api/create-payment", async (req, res) => {
       reference,
       bodyBase64Hash,
       amount,
-      asset: "GRAMGRAMGRAMGRAM      status: "pending",
+      asset: "TON",
+      status: "pending",
       senderAddr,
     });
 

--- a/content/applications/ton-pay/payment-integration/payments-tonconnect.mdx
+++ b/content/applications/ton-pay/payment-integration/payments-tonconnect.mdx
@@ -3,7 +3,7 @@ title: "How to send payments using TON Connect with TON Pay"
 sidebarTitle: "Send payments TON Connect"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 

--- a/content/applications/ton-pay/payment-integration/status-info.mdx
+++ b/content/applications/ton-pay/payment-integration/status-info.mdx
@@ -3,7 +3,7 @@ title: "How to check status and retrieve info with TON Pay"
 sidebarTitle: "Check status and retrieve info"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 
@@ -114,7 +114,7 @@ Use `status` to drive UI state and use `reference`, `bodyBase64Hash`, and `txHas
 
   - `pending` – the transfer is created and awaits confirmation on the blockchain.
   - `success` – the transfer is completed successfully; the trace completes without errors.
-  - `error` – the transfer fails; the trace completes with an error.
+  - `failed` – the transfer fails; the trace completes with an error.
 </ResponseField>
 
 <ResponseField

--- a/content/applications/ton-pay/payment-integration/transfer.mdx
+++ b/content/applications/ton-pay/payment-integration/transfer.mdx
@@ -3,7 +3,7 @@ title: "How to build a transfer in TON Pay"
 sidebarTitle: "Build a transfer"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 
@@ -184,7 +184,7 @@ await createTonPayTransfer(
     senderAddr: "<SENDER_ADDRESS>",       // shortened example; replace with a full wallet address
   },
   {
-    chain: "testnet",
+    chain: "mainnet", // USDTs only exist in mainnet
     apiKey: "<TONPAY_API_KEY>", // optional
   }
 );

--- a/content/applications/ton-pay/quick-start.mdx
+++ b/content/applications/ton-pay/quick-start.mdx
@@ -3,7 +3,7 @@ title: "Quick start with TON Pay"
 sidebarTitle: "Quick start"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 
@@ -210,7 +210,7 @@ Before installing and setting up the TON Pay SDK, the application must provide a
     1. Call `getTonPayTransferByReference(reference, options)` with the same `chain` and optional `apiKey` used during transfer creation.
     1. While the SDK returns `status: "pending"`, keep the UI in a loading or "confirming payment" state.
     1. When the status becomes `success`, show the confirmation UI and persist any result fields the application needs, such as `txHash` or `traceId`.
-    1. When the status becomes `error`, show the failure state and capture `errorCode` or `errorMessage` for diagnostics.
+    1. When the status becomes `failed`, show the failure state and capture `errorCode` or `errorMessage` for diagnostics.
 
     In a client-only flow, persist the `reference` after `pay(createMessage)` resolves and returns it. This is enough to resume status checks after a reload during polling, but it does not cover the period while the wallet approval screen is open. To avoid that gap, create the transfer on the server and persist the `reference` before opening the wallet.
 

--- a/content/applications/ton-pay/ui-integration/button-js.mdx
+++ b/content/applications/ton-pay/ui-integration/button-js.mdx
@@ -3,7 +3,7 @@ title: "How to add a TON Pay button using JS"
 sidebarTitle: "Add TON Pay button JS"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 

--- a/content/applications/ton-pay/ui-integration/button-react.mdx
+++ b/content/applications/ton-pay/ui-integration/button-react.mdx
@@ -3,7 +3,7 @@ title: "How to add a TON Pay button using React"
 sidebarTitle: "Add TON Pay button React"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 

--- a/content/applications/ton-pay/webhooks.mdx
+++ b/content/applications/ton-pay/webhooks.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Webhooks"
 tag: "beta"
 ---
 
-<Callout type="note">
+<Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>
 
@@ -319,14 +319,15 @@ Every webhook request includes an `X-TonPay-Signature` header containing an HMAC
 ```ts
 import { verifySignature, type WebhookPayload } from "@ton-pay/api";
 
-app.post("/webhook", (req, res) => {
-  const signature = req.headers["x-tonpay-signature"];
+app.post("/webhook", express.raw({ type: "application/json" }), (req, res) => {
+  const signature = req.headers["x-tonpay-signature"] as string;
+  const rawBody = req.body.toString("utf8");
 
-  if (!verifySignature(req.body, signature, process.env.TONPAY_API_SECRET)) {
+  if (!verifySignature(rawBody, signature, process.env.TONPAY_API_SECRET!)) {
     return res.status(401).json({ error: "Invalid signature" });
   }
 
-  const webhookData: WebhookPayload = req.body;
+  const webhookData: WebhookPayload = JSON.parse(rawBody);
 
   // Process the webhook in application-specific logic.
   res.status(200).json({ received: true });
@@ -420,17 +421,18 @@ Validate fields against the expected transaction data before marking an order as
 ```ts expandable
 import { verifySignature, type WebhookPayload } from "@ton-pay/api";
 
-app.post("/webhooks/tonpay", async (req, res) => {
+app.post("/webhooks/tonpay", express.raw({ type: "application/json" }), async (req, res) => {
   try {
     // 1. Verify signature
     const signature = req.headers["x-tonpay-signature"] as string;
+    const rawBody = req.body.toString("utf8");
 
-    if (!verifySignature(req.body, signature, process.env.TONPAY_API_SECRET!)) {
+    if (!verifySignature(rawBody, signature, process.env.TONPAY_API_SECRET!)) {
       console.error("Invalid webhook signature");
       return res.status(401).json({ error: "Invalid signature" });
     }
 
-    const webhookData: WebhookPayload = req.body;
+    const webhookData: WebhookPayload = JSON.parse(rawBody);
 
     // 2. Verify event type
     if (webhookData.event !== "transfer.completed") {

--- a/scripts/check-redirects.mjs
+++ b/scripts/check-redirects.mjs
@@ -92,15 +92,17 @@ const checkUnique = (config) => {
       ),
     );
   }
-  const noExplicitPermanent = redirects.filter((it) => it.permanent === undefined || typeof it.permanent !== 'boolean');
+  const noExplicitPermanent = redirects.filter(
+    (it) => it.permanent === undefined || typeof it.permanent !== 'boolean',
+  );
   if (noExplicitPermanent.length !== 0) {
     errors.push(
       composeErrorList(
         'Found sources with unset `permanent` field (neither `true` nor `false`):',
-        noExplicitPermanent.map(it => it.source),
-        'All redirects must set the `permanent` field to a boolean value!'
-      )
-    )
+        noExplicitPermanent.map((it) => it.source),
+        'All redirects must set the `permanent` field to a boolean value!',
+      ),
+    );
   }
   // If there are any errors
   if (errors.length !== 0) {

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -53,7 +53,7 @@ const paths: Path[] = [
   },
   {
     title: 'Applications',
-    description: 'Everything one needs to build dApps on TON.',
+    description: 'Build dApps, wallets, and payment services on TON.',
     icon: Blocks,
     links: [
       {
@@ -61,7 +61,7 @@ const paths: Path[] = [
         href: '/applications/appkit/overview',
       },
       {
-        title: 'Integrate payments with TON Pay',
+        title: 'Integrate invoice payments with TON Pay',
         href: '/applications/ton-pay/overview',
       },
       {
@@ -69,8 +69,8 @@ const paths: Path[] = [
         href: '/applications/walletkit/overview',
       },
       {
-        title: 'Create tools using SDKs',
-        href: '/applications/sdks',
+        title: 'Process Gram and USDT deposits and withdrawals',
+        href: '/applications/payments/setup',
       },
     ],
   },

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -252,12 +252,29 @@ p > span.style-tab-normal {
   margin-top: calc(var(--spacing) * 6);
 } */
 
-/* Removing background blur of the ToC popover */
+/* Remove background blur of the mobile header */
+#nd-docs-layout > header#nd-subnav {
+  --blur-sm: 0;
+  --tw-backdrop-blur: initial;
+  backdrop-filter: initial;
+  background-color: var(--color-fd-background);
+  /* does it target even */
+}
+
+/* Remove background blur of the ToC popover */
 #nd-docs-layout > div[data-toc-popover] > header {
   --blur-sm: 0;
   --tw-backdrop-blur: initial;
   backdrop-filter: initial;
   background-color: var(--color-fd-background);
+}
+
+/* Remove background blur of a Radix UI pop up */
+body > div[data-radix-popper-content-wrapper] > div[role='dialog'] {
+  --blur-sm: 0;
+  --tw-backdrop-blur: initial;
+  backdrop-filter: initial;
+  background-color: var(--color-fd-popover);
 }
 
 /* Make ToC fit its contents width */


### PR DESCRIPTION
Additional changes beyond the main guide:

* Put the payments section on the home page
* Correct mismatches in TON Pay docs wrt source code
* Use `caution` over `note` in Gram-related callouts on the TON Pay pages
* Add an invoice payment guide in TON Pay
* Remove background blur from the mobile header and Radix UI pop ups