### PR TITLE
feat: print debug information, route `.md`-suffixed paths to LLM Markdown sources

### DIFF
--- a/.github/workflows/deployer.yml
+++ b/.github/workflows/deployer.yml
@@ -60,29 +60,29 @@ jobs:
           npm run build
           # See some file contents
           nlines=50
-          target='llms.txt'
+          target='out/llms.txt'
           test -f "$target" && {
             echo -e "\nFirst $nlines lines of $target"
-            head -$nlines "out/$target"
-          } || echo "out/$target not found"
+            head -$nlines "$target" && echo
+          } || echo "$target not found"
           #
-          target='llms-full.txt'
+          target='out/llms-full.txt'
           test -f "$target" && {
             echo -e "\nFirst $nlines lines of $target"
-            head -$nlines "out/$target"
-          } || echo "out/$target not found"
+            head -$nlines "$target" && echo
+          } || echo "$target not found"
           #
-          target='llms/foundations/tlb/overview/content.md'
+          target='out/llms/foundations/tlb/overview/content.md'
           test -f "$target" && {
             echo -e "\nFirst $nlines lines of $target"
-            head -$nlines "out/$target"
-          } || echo "out/$target not found"
+            head -$nlines "$target" && echo
+          } || echo "$target not found"
           #
-          target='404.html'
+          target='out/404.html'
           test -f "$target" && {
             echo -e "\nFirst $nlines lines of $target"
-            head -$nlines "out/$target"
-          } || echo "out/$target not found"
+            head -$nlines "$target" && echo
+          } || echo "$target not found"
 
       - name: Save build cache
         id: next-cache-save

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,4 +2,5 @@ import staticConfig from './next.config.static';
 import vercelConfig from './next.config.vercel';
 
 const requestedConfig = process.env.NEXT_CONFIG === 'vercel' ? vercelConfig : staticConfig;
+console.log(requestedConfig.env);
 export default requestedConfig;

--- a/next.config.vercel.ts
+++ b/next.config.vercel.ts
@@ -44,6 +44,15 @@ const config: NextConfig = {
   },
   serverExternalPackages: ['typescript'],
   redirects: async () => loadDocsRedirects(),
+  rewrites: async () => ({
+    beforeFiles: [
+      {
+        // Map `.md` requests to LLM Markdown sources
+        source: '/:path((?!llms/|og/|api/|_next/).+)\\.md',
+        destination: '/llms/:path/content.md',
+      },
+    ],
+  }),
 };
 
 export default withMDX(config);

--- a/scripts/common.mjs
+++ b/scripts/common.mjs
@@ -36,6 +36,9 @@ export const prefix = '/docs';
 export const isGitHubPagesBuild =
   process.env.GITHUB_ACTIONS === 'true' || process.env.GITHUB_PAGES === 'true';
 
+// WARN: Must match next.config.ts check
+export const isVercelBuild = process.env.NEXT_CONFIG === 'vercel';
+
 /** @param src {string} */
 export function ansiRed(src) {
   return `\x1b[31m${src}\x1b[0m`;

--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -14,7 +14,7 @@
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, extname, dirname } from 'node:path';
 // Common
-import { prefix, outDir, isGitHubPagesBuild, getConfig, getRedirects } from './common.mjs';
+import { prefix, outDir, isGitHubPagesBuild, getConfig, getRedirects, isVercelBuild } from './common.mjs';
 
 /**
  * @param {string} path - file path
@@ -136,10 +136,46 @@ const generateStaticRedirects = (dir) => {
 };
 
 /** @param {string} dir */
+const generateSiblingMarkdownFiles = (dir) => {
+  const llms = join(dir, 'llms');
+  if (!existsSync(llms)) return { files: 0 };
+  let files = 0;
+  /** @param {string} cur */
+  const walk = (cur) => {
+    for (const entry of readdirSync(cur, { withFileTypes: true })) {
+      const path = join(cur, entry.name);
+      if (entry.isDirectory()) {
+        walk(path);
+        continue;
+      }
+      if (!entry.isFile() || entry.name !== 'content.md') continue;
+      const route = cur.slice(llms.length).replace(/^\/+/, ''); // or `dirname(path)` in place of `cur`
+      const target = join(dir, `${route}.md`);
+      const html = join(dir, `${route}.html`);
+      if (!existsSync(html)) continue;
+      writeFileWithDirs(target, readFileSync(path, 'utf8'));
+      files += 1;
+    }
+  };
+
+  walk(llms);
+  return { files };
+}
+
+/** @param {string} dir */
 const main = (dir) => {
   const pfx = 'post-build:';
+  if (isVercelBuild) {
+    console.log(pfx, 'skipped — not a static build');
+    process.exit(0);
+  }
+
+  console.log(pfx, 'generating sibling LLM markdown files...');
+  const { files: mdFiles } = generateSiblingMarkdownFiles(dir);
+  console.log(pfx, `${mdFiles} markdown files`);
+
   if (!isGitHubPagesBuild) {
-    console.log(pfx, 'skipped (not a GitHub Pages build)');
+    console.log(pfx, 'skipped GitHub Pages-only steps');
     process.exit(0);
   }
 


### PR DESCRIPTION
Closes #2239 (debug info)
Closes #2246 (`.md`-suffixed paths: routing for SSR or post-build generation for static builds)