### PR TITLE
feat(web3): add gateways and discoverability section to TON Proxy page

### DIFF
--- a/content/foundations/web3/ton-proxy.mdx
+++ b/content/foundations/web3/ton-proxy.mdx
@@ -134,3 +134,9 @@ The proxy also supports the HTTP `CONNECT` method, which enables WebSocket conne
 - **RLDP**: the reliable large datagram protocol over ADNL that carries HTTP requests and responses.
 - [TON Sites](/foundations/web3/ton-sites): web services accessible through TON Proxy.
 - [TON DNS](/foundations/web3/ton-dns): resolves `.ton` domain names to ADNL addresses for request routing.
+
+## Gateways and discoverability
+
+TON Sites are also reachable without running a local proxy through third-party HTTP gateways. [`dweb3.wtf`](https://dweb3.wtf) is a resolver for decentralized webpages that supports multiple Web3 namespaces, including `.ton` domains: for example, `foundation.ton` is available at [`foundation.ton.dweb3.wtf`](https://foundation.ton.dweb3.wtf). Note that accessing a TON Site through a public gateway relies on the gateway operator, unlike running `rldp-http-proxy` locally.
+
+Sites linked to a `.ton` domain are also made searchable through the [`web3compass.net`](https://www.web3compass.net) search engine, which indexes decentralized websites and their content much like DuckDuckGo, Brave Search, or Google do for the traditional web. Indexing coverage is reported on its [statistics page](https://www.web3compass.net/statistics).


### PR DESCRIPTION
## Description

Two related additions covering TON Sites discoverability tooling, in a new
"Gateways and discoverability" section on `foundations/web3/ton-proxy`:

1. Adds dweb3 (decentralized webpage resolver supporting `.ton` domains,
   e.g. `foundation.ton` → foundation.ton.dweb3.wtf) as a third-party HTTP
   gateway option, with a note on gateway operator trust.
2. Adds web3compass (decentralized-web search engine) for discovering
   `.ton`-linked sites and their content.

## Related Issue

N/A — additive content addition.