### PR TITLE
chore(subsecond): add third-party live verification of ~1s finalization lag

### DIFF
--- a/content/subsecond.mdx
+++ b/content/subsecond.mdx
@@ -23,6 +23,11 @@ As of April 9th 2026, mainnet runs with a block interval of about 400 ms instead
 - Together with the consensus update, the [Streaming API v2](#ton-center-streaming-api-v2) delivers status updates with 30 to 100ms latency.
 - Testnet remains the primary environment for project testing.
 
+<Callout type="tip">
+  **Third-party verification.** [OpenChainBench](https://openchainbench.com/benchmarks/l1-finality) is an open-source, live benchmark that independently measures TON masterchain finalization (listed under the **Gram** ticker following the [rename vote](https://ton.vote/EQDQvywF226NXojPky_9gwbCz0FPoygqY11bGl03SONNBs5V/proposal/EQAv-VS2OM80SYLB0ouRWRcpFg4J0L-egUf1-utF-OJ6h0rK), via `tonapi.io`) at **~0.4 s (p50, 24h)**, which confirms the ~1 s finalization lag target above. The benchmark ranks 11 L1 chains under an open methodology; TON currently leads finality time in the comparison. Source: [github.com/ChainBench/OpenChainBench](https://github.com/ChainBench/OpenChainBench) (MIT), data CC-BY-4.0.
+</Callout>
+
+
 ## Example of sub-second user experience in action
 
 <video


### PR DESCRIPTION
## Summary

Add a `<Callout type="tip">` below the finalization table on `content/subsecond.mdx` that points readers to an independent, live benchmark of TON masterchain finalization latency. Confirms the ~1s finalization lag figure from the table with an external data source, and clarifies that the benchmark lists TON under the **Gram** ticker following the recent [rename vote](https://ton.vote/EQDQvywF226NXojPky_9gwbCz0FPoygqY11bGl03SONNBs5V/proposal/EQAv-VS2OM80SYLB0ouRWRcpFg4J0L-egUf1-utF-OJ6h0rK).

## Why

The Catchain 2.0 upgrade shipped April 9th 2026 with a stated target of ~1s finalization lag. [OpenChainBench](https://openchainbench.com/benchmarks/l1-finality) has been continuously measuring TON masterchain commit latency via `tonapi.io` since launch and currently reports **~0.4 s (p50, 24h)**, which independently validates the upgrade delivered on its target and gives readers a live dashboard to monitor it.

Third-party verification of a marketing-relevant claim is generally more persuasive than the same claim without external corroboration. This link adds one such source without changing anything the page already says.

Bonus: OCB currently ranks TON as **#1 for finality time** across the 11 L1 chains it tracks (ahead of SUI, Stellar, Solana, Ethereum, etc.).

## About OpenChainBench

- Open methodology: https://openchainbench.com/methodology
- Source (MIT): https://github.com/ChainBench/OpenChainBench
- Data license: CC-BY-4.0
- Refreshed every 10 s, 3 measurement regions
- Uses `tonapi.io` for TON masterchain polling, no private endpoint or paid tier
- Funded by Mobula; all chains including funder-adjacent ones are measured with the same probe

## Note on the "Gram" ticker

Following the community vote to rename Toncoin → Gram, OCB lists the L1 under the **Gram** ticker with the same underlying chain (masterchain commit via `tonapi.io`). The Callout mentions this explicitly so readers do not confuse the entries.

## Test plan

- [x] Single-file addition, 1 Callout block inserted below the finalization table
- [x] Table markdown untouched, all other page structure preserved
- [x] Matches the page's existing `<Callout type="tip">` style
- [x] Reference URLs verified live

Happy to reword, move to a plain note, or drop entirely if this does not fit the docs' tone.