### PR TITLE
chore: clarify TON Pay status

### DIFF
--- a/content/applications/meta.json
+++ b/content/applications/meta.json
@@ -7,6 +7,7 @@
     "appkit",
     "walletkit",
     "ton-connect",
-    "payments"
+    "payments",
+    "ton-pay"
   ]
 }

--- a/content/applications/overview.mdx
+++ b/content/applications/overview.mdx
@@ -21,15 +21,6 @@ The rest of the page covers higher-level SDKs composed of a variety of smaller l
 
 Read more about [AppKit](/applications/appkit/overview).
 
-## TON Pay (beta)
-
-[TON Pay](/applications/ton-pay/overview) is an SDK for accepting TON payments in web applications. TON Pay provides the payments layer for TON integration — a unified interface for creating, verifying, and managing payments. It supports web apps, bots, and backend services.
-
-- Repository on GitHub: [`RSquad/ton-pay`](https://github.com/RSquad/ton-pay)
-- NPM packages: [`@ton-pay/api`](https://www.npmjs.com/package/@ton-pay/api) and [`@ton-pay/ui-react`](https://www.npmjs.com/package/@ton-pay/ui-react)
-
-Read more about [TON Pay](/applications/ton-pay/overview).
-
 ## WalletKit
 
 [WalletKit](/applications/walletkit/overview) is an SDK for integrating TON into wallet services. WalletKit is the wallet-side counterpart to [AppKit](#appkit). It allows custodial and non-custodial wallet providers to manage wallets, sign transactions, and integrate TON across web, mobile, and browser extension platforms.
@@ -55,3 +46,19 @@ Read more about [TON Connect](/applications/ton-connect/overview).
 ## Payment processing
 
 Conceptual overview of correct ways of monitoring and handling blockchain transactions for business applications: [Payment processing](/applications/payments/overview)
+
+## TON Pay (beta)
+
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate. To process Gram or jetton payments, including USDT on TON, prefer setting up the [self-hosted payment processor](/applications/payments/setup).
+</Callout>
+
+[TON Pay](/applications/ton-pay/overview) is an SDK for accepting TON payments in web applications. TON Pay provides the payments layer for TON integration — a unified interface for creating, verifying, and managing payments. It supports web apps, bots, and backend services.
+
+- Repository on GitHub: [`RSquad/ton-pay`](https://github.com/RSquad/ton-pay)
+- NPM packages: [`@ton-pay/api`](https://www.npmjs.com/package/@ton-pay/api) and [`@ton-pay/ui-react`](https://www.npmjs.com/package/@ton-pay/ui-react)
+
+Read more about [TON Pay](/applications/ton-pay/overview).

--- a/content/applications/payments/setup.mdx
+++ b/content/applications/payments/setup.mdx
@@ -5,8 +5,6 @@ sidebarTitle: "Self-hosted setup"
 
 <Callout type="caution">
   This guide shows one of the possible ways to set up Gram and USDT (on TON) payments in business applications. For more info and alternative approaches, see the [payment processing overview](/applications/payments/overview).
-
-  To enable invoices in regular dApps, use [TON Pay](/applications/ton-pay/overview) instead.
 </Callout>
 
 [Bicycle](https://github.com/gobicycle/bicycle) is a self-hosted payment processor for TON. It runs next to an exchange, custodial wallet, merchant backend, or payment service and provides a REST API for:

--- a/content/applications/ton-pay/api-reference.mdx
+++ b/content/applications/ton-pay/api-reference.mdx
@@ -3,6 +3,13 @@ title: "TON Pay API reference"
 sidebarTitle: "API reference"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>

--- a/content/applications/ton-pay/invoices.mdx
+++ b/content/applications/ton-pay/invoices.mdx
@@ -3,6 +3,13 @@ title: "How to set up invoice Gram and USDT payments with TON Pay"
 sidebarTitle: "Invoices"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   This guide implements invoice deposits. For static per-user deposit addresses, use [direct payment processing](/applications/payments/overview) **instead** of TON Pay.
 </Callout>

--- a/content/applications/ton-pay/meta.json
+++ b/content/applications/ton-pay/meta.json
@@ -1,6 +1,7 @@
 {
   "$schema": "../../../meta-schema.json",
   "title": "TON Pay",
+  "tag": "legacy",
   "pages": [
     "overview",
     "quick-start",

--- a/content/applications/ton-pay/on-ramp.mdx
+++ b/content/applications/ton-pay/on-ramp.mdx
@@ -3,6 +3,13 @@ title: "On-ramp in TON Pay SDK"
 sidebarTitle: "On-ramp"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>

--- a/content/applications/ton-pay/overview.mdx
+++ b/content/applications/ton-pay/overview.mdx
@@ -3,6 +3,13 @@ title: "TON Pay SDK overview"
 sidebarTitle: "Overview"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>

--- a/content/applications/ton-pay/payment-integration/payments-react.mdx
+++ b/content/applications/ton-pay/payment-integration/payments-react.mdx
@@ -3,6 +3,13 @@ title: "How to send payments using TON Pay React hook"
 sidebarTitle: "Send payments React"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>

--- a/content/applications/ton-pay/payment-integration/payments-tonconnect.mdx
+++ b/content/applications/ton-pay/payment-integration/payments-tonconnect.mdx
@@ -3,6 +3,13 @@ title: "How to send payments using TON Connect with TON Pay"
 sidebarTitle: "Send payments TON Connect"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>

--- a/content/applications/ton-pay/payment-integration/status-info.mdx
+++ b/content/applications/ton-pay/payment-integration/status-info.mdx
@@ -3,6 +3,13 @@ title: "How to check status and retrieve info with TON Pay"
 sidebarTitle: "Check status and retrieve info"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>

--- a/content/applications/ton-pay/payment-integration/transfer.mdx
+++ b/content/applications/ton-pay/payment-integration/transfer.mdx
@@ -3,6 +3,13 @@ title: "How to build a transfer in TON Pay"
 sidebarTitle: "Build a transfer"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>

--- a/content/applications/ton-pay/quick-start.mdx
+++ b/content/applications/ton-pay/quick-start.mdx
@@ -3,6 +3,13 @@ title: "Quick start with TON Pay"
 sidebarTitle: "Quick start"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>

--- a/content/applications/ton-pay/ui-integration/button-js.mdx
+++ b/content/applications/ton-pay/ui-integration/button-js.mdx
@@ -3,6 +3,13 @@ title: "How to add a TON Pay button using JS"
 sidebarTitle: "Add TON Pay button JS"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>

--- a/content/applications/ton-pay/ui-integration/button-react.mdx
+++ b/content/applications/ton-pay/ui-integration/button-react.mdx
@@ -3,6 +3,13 @@ title: "How to add a TON Pay button using React"
 sidebarTitle: "Add TON Pay button React"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>

--- a/content/applications/ton-pay/webhooks.mdx
+++ b/content/applications/ton-pay/webhooks.mdx
@@ -4,6 +4,13 @@ sidebarTitle: "Webhooks"
 tag: "beta"
 ---
 
+<Callout
+  type="note"
+  title="Integration availability"
+>
+  New integrations are unavailable. Existing integrations continue to operate.
+</Callout>
+
 <Callout type="caution">
   TON Pay uses the previous, now deprecated currency name instead of Gram/GRAM.
 </Callout>


### PR DESCRIPTION
Existing integrations continue to operate, yet new integrations are unavailable. TON Pay documentation pages remain accessible for existing users (as of right now). However, these pages may eventually be removed, especially if or once a new tool that replaces the invoice-based payment processing offered by TON Pay becomes available.

For general Gram and USDT (on TON) payment processing in business applications, refer to [this guide](https://docs.ton.org/applications/payments/setup) and the rest of the [Payment processing](https://docs.ton.org/applications/payments/overview) sub-section.

Follow-up to #2272