### PR TITLE
chore(whitepapers): fix the dead Ethereum whitepaper citation

### DIFF
--- a/content/foundations/whitepapers/ton.mdx
+++ b/content/foundations/whitepapers/ton.mdx
@@ -2253,7 +2253,7 @@ The "bulk sales" mechanism will probably be used extensively during the initial 
 
 <span id="ref-1">[1]</span> K. Birman, *Reliable Distributed Systems: Technologies, Web Services and Applications*, Springer, 2005.
 
-<span id="ref-2">[2]</span> V. Buterin, *Ethereum: A next-generation smart contract and decentralized application platform*, https://github.com/ethereum/wiki/wiki/White-Paper, 2013.
+<span id="ref-2">[2]</span> V. Buterin, *Ethereum: A next-generation smart contract and decentralized application platform*, https://ethereum.org/en/whitepaper/, 2013.
 
 <span id="ref-3">[3]</span> M. Ben-Or, B. Kelmer, T. Rabin, *Asynchronous secure computations with optimal resilience*, in *Proceedings of the thirteenth annual ACM symposium on Principles of distributed computing*, p. 183–192. ACM, 1994.
 


### PR DESCRIPTION
## Problem

Reference **[2]** in `content/foundations/whitepapers/ton.mdx` cites the Ethereum whitepaper at `https://github.com/ethereum/wiki/wiki/White-Paper`. The `ethereum/wiki` repository has been deleted, so that URL returns 404 and the citation no longer resolves.

## Change

One line. The citation now points at the whitepaper's current canonical home:

`https://ethereum.org/en/whitepaper/` — HTTP 200, page title "Ethereum Whitepaper | ethereum.org".

## Verification

- Old URL: **404**. New URL: **200**, and the page title matches the cited document.
- Control test: `https://ethereum.org/en/bogus-path-zzz999/` returns a genuine 404, so a 200 from that host means the page really exists rather than a catch-all handler.
- **No formatting risk.** This file is excluded from all three of your format gates: `.prettierignore` lists `*.mdx`, `.remarkignore` lists `content/foundations/whitepapers/ton.mdx` explicitly, and the `ignorePaths` in `.cspell.jsonc` lists it too. So both `check:fmt:some` and the CSpell action skip it, and the change is a pure text substitution on one line — line count and every other byte are unchanged.

## A second dead link I deliberately did **not** touch

Footnote 1 at line 2292 cites `https://github.com/ethereum/wiki/wiki/Sharding-FAQ` — also 404, from the same deleted repository. I left it as-is because I could not find a replacement I am able to vouch for, and I would rather flag it than quietly point the citation somewhere else:

- **`eth.wiki/sharding/Sharding-FAQs` looks like the successor and returns HTTP 200 — but it is not the FAQ.** That host is a blanket redirect: every path on it, including a deliberately bogus one I tested, lands on `https://ethereum.org/` and returns a byte-identical 306,918-byte response. Checking only the status code would have made this look like a valid fix.
- **`github.com/ethereum/sharding`** is alive, but its `docs/doc.md` is the sharding *specification*, not the FAQ (it contains no occurrence of "FAQ"), and the repository has been archived since June 2018.
- **`ethereum.org/en/roadmap/danksharding/`** is live, but it is a different document. Substituting it would silently change what the footnote cites.
- A **Wayback snapshot** would be the faithful fix, but archive.org rate-limited my requests and I am not willing to put in a URL I have not verified myself.

Since this is a footnote in a published whitepaper, which of those you want — or whether the URL should simply be dropped — is your call rather than mine. Happy to add it to this PR once you say which.

For context on why these survived: `check:links` in `package.json` is currently a placeholder (`echo 'TODO: REPLACE mint broken-links ...'`), so nothing in CI is validating external URLs at the moment.
