### PR TITLE
docs: add OpenChainBench TON RPC benchmark to network status page

### DIFF
--- a/content/api/overview.mdx
+++ b/content/api/overview.mdx
@@ -70,6 +70,10 @@ TON Center is the official provider of HTTP APIs for TON: read blockchain data, 
   </Card>
 </Columns>
 
+## Endpoint latency
+
+[OpenChainBench](https://openchainbench.com/benchmarks/gram-rpc) continuously benchmarks public TON RPC providers (TON Center, OnFinality, Tatum, Uniblock) with p50/p90/p99 latency measured every 60 seconds from US-East, EU-West and Singapore. Useful for picking the fastest endpoint for your region.
+
 ## References
 
 - [TON node and liteserver source](https://github.com/ton-blockchain/ton)

--- a/content/api/overview.mdx
+++ b/content/api/overview.mdx
@@ -40,6 +40,8 @@ For available SDKs that rely on some of these APIs, see the [SDK overview](/appl
 | **Authentication**         | [API key][etc-key]                         |
 | **Documentation**          | [Docs][etc-stream-doc]                     |
 
+For live latency data across public TON HTTP endpoints, see [OpenChainBench](https://openchainbench.com/benchmarks/gram-rpc) — p50/p90/p99 measured every 60 seconds from US-East, EU-West and Singapore.
+
 ## TON Center
 
 TON Center is the official provider of HTTP APIs for TON: read blockchain data, query smart contracts, send transactions.
@@ -69,10 +71,6 @@ TON Center is the official provider of HTTP APIs for TON: read blockchain data, 
     Low-latency updates on subscriptions through SSE or WebSockets.
   </Card>
 </Columns>
-
-## Endpoint latency
-
-[OpenChainBench](https://openchainbench.com/benchmarks/gram-rpc) continuously benchmarks public TON RPC providers (TON Center, OnFinality, Tatum, Uniblock) with p50/p90/p99 latency measured every 60 seconds from US-East, EU-West and Singapore. Useful for picking the fastest endpoint for your region.
 
 ## References
 

--- a/content/nodes/status.mdx
+++ b/content/nodes/status.mdx
@@ -7,7 +7,6 @@ This page lists websites that show if specific parts of TON blockchain are worki
 |                                                                  |                                                               |
 | ---------------------------------------------------------------- | ------------------------------------------------------------- |
 | [https://tonstat.us/](https://tonstat.us/)                       | HTTP and ADNL server availability and performance.            |
-| [https://openchainbench.com/benchmarks/gram-rpc](https://openchainbench.com/benchmarks/gram-rpc) | Live p50/p90/p99 latency benchmarks for TON RPC providers (TON Center, OnFinality, Tatum, Uniblock), measured every 60 seconds from 3 global regions. |
 | [https://status.toncenter.com/](https://status.toncenter.com/)   | Low-level metrics, such as latencies, rates, and loads.       |
 | [https://validators.ton.org/](https://validators.ton.org/)       | Official validation dashboard.                                |
 | [https://tonscan.com/validation](https://tonscan.com/validation) | Pretty validation dashboard.                                  |

--- a/content/nodes/status.mdx
+++ b/content/nodes/status.mdx
@@ -7,6 +7,7 @@ This page lists websites that show if specific parts of TON blockchain are worki
 |                                                                  |                                                               |
 | ---------------------------------------------------------------- | ------------------------------------------------------------- |
 | [https://tonstat.us/](https://tonstat.us/)                       | HTTP and ADNL server availability and performance.            |
+| [https://openchainbench.com/benchmarks/gram-rpc](https://openchainbench.com/benchmarks/gram-rpc) | Live p50/p90/p99 latency benchmarks for TON RPC providers (TON Center, OnFinality, Tatum, Uniblock), measured every 60 seconds from 3 global regions. |
 | [https://status.toncenter.com/](https://status.toncenter.com/)   | Low-level metrics, such as latencies, rates, and loads.       |
 | [https://validators.ton.org/](https://validators.ton.org/)       | Official validation dashboard.                                |
 | [https://tonscan.com/validation](https://tonscan.com/validation) | Pretty validation dashboard.                                  |


### PR DESCRIPTION
Adds [OpenChainBench](https://openchainbench.com/benchmarks/gram-rpc) to the Network Status page next to tonstat.us.

**What it does:** Continuously probes TON RPC providers (TON Center, OnFinality, Tatum, Uniblock) every 60 seconds from US-East, EU-West and Singapore, publishing live p50/p90/p99 latency rankings.

**Why it fits here:** This page already lists tonstat.us for availability/performance monitoring. OpenChainBench adds the latency-benchmark dimension for the same providers — developers can see not just if a node is up, but which one responds fastest from their region.

Open source: https://github.com/ChainBench/OpenChainBench